### PR TITLE
V 1.10.3

### DIFF
--- a/_includes/partials/home/tools.liquid
+++ b/_includes/partials/home/tools.liquid
@@ -37,6 +37,8 @@
                                             <option value="stripspecialchars">Strip special characters</option>
                                             <option value="removenumbers">Remove all numbers</option>
                                             <option value="removeletters">Remove all letters</option>
+                                            <option value="uppercaseonly">Uppercase only</option>
+                                            <option value="lowercaseonly">Lowercase only</option>
                                             <option value="specialcharsonly">Special characters only</option>
                                             <option value="alphabet">Letters to alphabet number</option>
                                             <option value="urlencode">URL Encode</option>

--- a/_site/404.html
+++ b/_site/404.html
@@ -149,8 +149,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.1" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.1</small>
+            <abbr title="Release version: v1.10.3" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.3</small>
             </abbr>
         </div>
     </div>

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -216,6 +216,12 @@ toolChange.addEventListener("click", function() {
         case "alphabet":
             document.getElementById("textResults").textContent = lettersToNumbers(textResults);
             break;
+        case "uppercaseonly":
+            document.getElementById("textResults").textContent = lettersOnlyCap(textResults);
+            break;
+        case "lowercaseonly":
+            document.getElementById("textResults").textContent = lettersOnlyLow(textResults);
+            break;
         case "specialcharsonly":
             document.getElementById("textResults").textContent = specialCharsOnly(textResults);
             break;

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -100,7 +100,7 @@ function stringStats(string, stat, delimiter) {
             return lettersOnly(string).length;
         break;
         case "letter-count-caps":
-            return lettersOnlyCap(string).length;
+            return lettersOnlyCap(string, true).length;
         break;
         case "letter-count-low":
             return lettersOnlyLow(string).length;

--- a/_site/assets/js/tools.js
+++ b/_site/assets/js/tools.js
@@ -27,7 +27,7 @@ function lettersOnly(string, preserveSpaces) {
 
 // Capital letters only
 function lettersOnlyCap(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[^A-Z ]/g : /[A-Z]/g;
+    let regex = preserveSpaces === true ? /[^A-Z ]/g : /[^A-Z]/g;
     return string.replace(regex, "");
 }
 

--- a/_site/ciphers/index.html
+++ b/_site/ciphers/index.html
@@ -801,8 +801,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.1" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.1</small>
+            <abbr title="Release version: v1.10.3" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.3</small>
             </abbr>
         </div>
     </div>

--- a/_site/files/index.html
+++ b/_site/files/index.html
@@ -840,8 +840,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.1" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.1</small>
+            <abbr title="Release version: v1.10.3" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.3</small>
             </abbr>
         </div>
     </div>

--- a/_site/hex/index.html
+++ b/_site/hex/index.html
@@ -389,8 +389,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.1" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.1</small>
+            <abbr title="Release version: v1.10.3" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.3</small>
             </abbr>
         </div>
     </div>

--- a/_site/index.html
+++ b/_site/index.html
@@ -972,8 +972,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.1" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.1</small>
+            <abbr title="Release version: v1.10.3" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.3</small>
             </abbr>
         </div>
     </div>

--- a/_site/index.html
+++ b/_site/index.html
@@ -760,6 +760,8 @@
                                             <option value="stripspecialchars">Strip special characters</option>
                                             <option value="removenumbers">Remove all numbers</option>
                                             <option value="removeletters">Remove all letters</option>
+                                            <option value="uppercaseonly">Uppercase only</option>
+                                            <option value="lowercaseonly">Lowercase only</option>
                                             <option value="specialcharsonly">Special characters only</option>
                                             <option value="alphabet">Letters to alphabet number</option>
                                             <option value="urlencode">URL Encode</option>

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -216,6 +216,12 @@ toolChange.addEventListener("click", function() {
         case "alphabet":
             document.getElementById("textResults").textContent = lettersToNumbers(textResults);
             break;
+        case "uppercaseonly":
+            document.getElementById("textResults").textContent = lettersOnlyCap(textResults);
+            break;
+        case "lowercaseonly":
+            document.getElementById("textResults").textContent = lettersOnlyLow(textResults);
+            break;
         case "specialcharsonly":
             document.getElementById("textResults").textContent = specialCharsOnly(textResults);
             break;

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -100,7 +100,7 @@ function stringStats(string, stat, delimiter) {
             return lettersOnly(string).length;
         break;
         case "letter-count-caps":
-            return lettersOnlyCap(string).length;
+            return lettersOnlyCap(string, true).length;
         break;
         case "letter-count-low":
             return lettersOnlyLow(string).length;

--- a/assets/js/tools.js
+++ b/assets/js/tools.js
@@ -27,7 +27,7 @@ function lettersOnly(string, preserveSpaces) {
 
 // Capital letters only
 function lettersOnlyCap(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[^A-Z ]/g : /[A-Z]/g;
+    let regex = preserveSpaces === true ? /[^A-Z ]/g : /[^A-Z]/g;
     return string.replace(regex, "");
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convrtrjs",
-  "version": "1.10.1",
+  "version": "1.10.3",
   "description": "A simple JavaScript based tool to quickly convert text between different formats",
   "tagline": "For everlost and Grollow!",
   "main": "index.html",


### PR DESCRIPTION
## New features
- Surfaced 2 additional text tools that were introduced in #15 - uppercase only and lowercase only 

## Bug fixes
- Fixed the "Capital letter only" frequency count, which wasn't returning an accurate value
- Fixed a missing caret in uppercase removal, causing incorrect replacements to be run
