### PR TITLE
V 1.10.5

### DIFF
--- a/_site/404.html
+++ b/_site/404.html
@@ -149,8 +149,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.4" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.4</small>
+            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.5</small>
             </abbr>
         </div>
     </div>

--- a/_site/assets/js/ciphers/ciphers.js
+++ b/_site/assets/js/ciphers/ciphers.js
@@ -63,9 +63,9 @@ function vignereEncrypt(string, key) {
         const c = string.charAt(i);
         if (isLetter(c)) {
             if (isUpperCase(c)) {
-                result += String.fromCharCode((c.charCodeAt(0) + key.toUpperCase().charCodeAt(j) - 2 * 65) % 26 + 65);
+                result += String.fromCharCode((c.charCodeAt(0) + key.toLocaleUpperCase().charCodeAt(j) - 2 * 65) % 26 + 65);
             } else {
-                result += String.fromCharCode((c.charCodeAt(0) + key.toLowerCase().charCodeAt(j) - 2 * 97) % 26 + 97);
+                result += String.fromCharCode((c.charCodeAt(0) + key.toLocaleLowerCase().charCodeAt(j) - 2 * 97) % 26 + 97);
             }
         } else {
             result += c;
@@ -83,9 +83,9 @@ function vignereDecrypt(string, key) {
         const c = string.charAt(i);
         if (isLetter(c)) {
             if (isUpperCase(c)) {
-                result += String.fromCharCode(90 - (25 - (c.charCodeAt(0) - key.toUpperCase().charCodeAt(j))) % 26);
+                result += String.fromCharCode(90 - (25 - (c.charCodeAt(0) - key.toLocaleUpperCase().charCodeAt(j))) % 26);
             } else {
-                result += String.fromCharCode(122 - (25 - (c.charCodeAt(0) - key.toLowerCase().charCodeAt(j))) % 26);
+                result += String.fromCharCode(122 - (25 - (c.charCodeAt(0) - key.toLocaleLowerCase().charCodeAt(j))) % 26);
             }
         } else {
             result += c;

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -1,9 +1,14 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
-function shiftHexString(string, shiftValue) {
-    return hexToString(string).split("").map(c => 
-            ord(c) + parseInt(shiftValue)
-        ).join(" ");
+function shiftHexString(string, shiftValue, delimiter) {
+    let validHex = /[0-9A-Fa-f]+$/g;
+    if(validHex.test(string)) {
+        return hexToString(string, delimiter).split("").map(c => 
+            (ord(c) + parseInt(shiftValue)).toString(16)
+        ).join(delimiter);
+    } else {
+        throw Error("Hexadecimal contains invalid characters");
+    }
 }
 
 // Reverse Hex nibbles
@@ -18,6 +23,7 @@ const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
     let shiftValue = document.getElementById("shiftValue");
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -34,11 +40,11 @@ shiftButton.addEventListener("click", function() {
         return false;
     }
 
-    document.getElementById("text-tab-pane").textContent = decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value));
-    document.getElementById("binary-tab-pane").textContent = stringToBinary(decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value)));
-    document.getElementById("hex-tab-pane").textContent = stringToHex(decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value)));
-    document.getElementById("base64-tab-pane").textContent = stringToBase64(decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value)));
-    document.getElementById("decimal-tab-pane").textContent =  shiftHexString(shiftString.value.trim(), shiftValue.value);
+    document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
+    document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
+    document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("decimal-tab-pane").textContent =  string2Dec(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
 });
 
 // Reverse Hex

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -40,6 +40,13 @@ shiftButton.addEventListener("click", function() {
         return false;
     }
 
+    try {
+        shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
+    } catch (e) {
+        showToast("Error", `An error occured trying to shift the hex string: ${e.message}`, "danger");
+        return;
+    }
+
     document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
     document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
     document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -46,7 +46,7 @@ function morseToString(string) {
 // Convert to Morse
 function stringToMorse(string) {
     return string
-            .toUpperCase()
+            .toLocaleUpperCase()
             .split(" ")
             .map(word => word
                         .split("") // get character code,

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -9,7 +9,7 @@ function binaryToString(string) {
             ...string.split(" ").map(bin => parseInt(bin, 2))
         );
     } else {
-        throw Error("Binary is not valid");
+        throw Error("Not a valid Binary string");
     }
 }
 
@@ -21,7 +21,7 @@ function base64ToString(string) {
             return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
         }).join(""));
     } catch (e) {
-        throw Error("not a valid Base64 string");
+        throw Error("Not a valid Base64 string");
     }
 }
 

--- a/_site/assets/js/toolkit.js
+++ b/_site/assets/js/toolkit.js
@@ -25,10 +25,10 @@ function isLetter(string) {
 
 // Check is character/string is uppercase or lowecase
 function isUpperCase(string) {
-    if (string === string.toUpperCase()) {
+    if (string === string.toLocaleUpperCase()) {
         return true;
     }
-    if (string === string.toLowerCase()) {
+    if (string === string.toLocaleLowerCase()) {
         return false;
     }
 }

--- a/_site/assets/js/toolkit.js
+++ b/_site/assets/js/toolkit.js
@@ -69,18 +69,23 @@ function stringToHex(string, delimiter) { // UTF-8
 
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
-function hexToString(string) {
-    try {
-        return decodeURIComponent(
-            string.replace(/\s|-|:|\.|\!|,|(0x)/g, "") // remove spaces
-            .replace(/[0-9a-f]{2}/g, "%$&") // add "%" before each 2 characters
-        );
-    } catch (e) {
-        throw Error("Hexadecimal is not valid");
+function hexToString(string, delimiter) {
+    let validHex = /[0-9A-Fa-f]+$/g;
+
+    if (validHex.test(string)) {
+        let hexDelimiter = delimiter ? delimiter : document.getElementById("hexDelimiter").value;
+        const hex = Array.from(string.trim().split(hexDelimiter));
+        const len = hex.length;
+        let hexArray = [];
+
+        for (let i = 0; i < len; i++) {
+            hexArray.push(String.fromCharCode(parseInt(hex[i], 16)));
+        }
+        return hexArray.join("");
+    } else {
+        throw Error("Hexadecimal contains invalid characters");
     }
 }
-// Previous method: https://stackoverflow.com/a/69420340/3172872
-// return decodeURIComponent("%" + string.replace(/ /g, "").match(/.{1,2}/g).join("%"));
 
 // Convert to Base64
 // https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings

--- a/_site/assets/js/tools.js
+++ b/_site/assets/js/tools.js
@@ -1,6 +1,6 @@
 // Remove spaces
 function stripSpaces(string) {
-    return string.replace(/ /gi, "");
+    return string.replace(/ /g, "");
 }
 
 // Uppercase string
@@ -21,7 +21,7 @@ function numbersOnly(string, preserveSpaces) {
 
 // Letters only
 function lettersOnly(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[^a-z ]/gi : /[^a-z]/gi;
+    let regex = preserveSpaces === true ? /[^A-Za-z ]/g : /[^A-Za-z]/g;
     return string.replace(regex, "");
 }
 
@@ -39,13 +39,13 @@ function lettersOnlyLow(string, preserveSpaces) {
 
 // Remove special characters
 function stripSpecialChars(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[^a-z0-9 ]/gi : /[^a-z0-9]/gi;
+    let regex = preserveSpaces === true ? /[^0-9A-Za-z ]/g : /[^0-9A-Za-z]/g;
     return string.replace(regex, "");
 }
 
 // Remove all letters
 function stripLetters(string) {
-    return string.replace(/[a-z]/gi, "");
+    return string.replace(/[A-Za-z]/g, "");
 }
 
 // Remove all numbers
@@ -55,18 +55,18 @@ function stripNumbers(string) {
 
 // Special characters only
 function specialCharsOnly(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[a-z0-9]/gi : /[a-z0-9 ]/gi;
+    let regex = preserveSpaces === true ? /[0-9A-Za-z]/g : /[0-9A-Za-z ]/g;
     return string.replace(regex, "");
 }
 
 // URL encode
 function urlEncode(string) {
-    return encodeURIComponent(string).replace(/%20/gi, "+");
+    return encodeURIComponent(string).replace(/%20/g, "+");
 }
 
 // URL decode
 function urlDecode(string) {
-    return decodeURIComponent(string).replace(/\+/gi, " ");
+    return decodeURIComponent(string).replace(/\+/g, " ");
 }
 
 // Convert letters to their alphabet number: A = 1, B = 2, Z = 26

--- a/_site/ciphers/index.html
+++ b/_site/ciphers/index.html
@@ -801,8 +801,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.4" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.4</small>
+            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.5</small>
             </abbr>
         </div>
     </div>

--- a/_site/files/index.html
+++ b/_site/files/index.html
@@ -840,8 +840,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.4" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.4</small>
+            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.5</small>
             </abbr>
         </div>
     </div>

--- a/_site/hex/index.html
+++ b/_site/hex/index.html
@@ -389,8 +389,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.4" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.4</small>
+            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.5</small>
             </abbr>
         </div>
     </div>

--- a/_site/index.html
+++ b/_site/index.html
@@ -972,8 +972,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.4" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.4</small>
+            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.5</small>
             </abbr>
         </div>
     </div>

--- a/assets/js/ciphers/ciphers.js
+++ b/assets/js/ciphers/ciphers.js
@@ -63,9 +63,9 @@ function vignereEncrypt(string, key) {
         const c = string.charAt(i);
         if (isLetter(c)) {
             if (isUpperCase(c)) {
-                result += String.fromCharCode((c.charCodeAt(0) + key.toUpperCase().charCodeAt(j) - 2 * 65) % 26 + 65);
+                result += String.fromCharCode((c.charCodeAt(0) + key.toLocaleUpperCase().charCodeAt(j) - 2 * 65) % 26 + 65);
             } else {
-                result += String.fromCharCode((c.charCodeAt(0) + key.toLowerCase().charCodeAt(j) - 2 * 97) % 26 + 97);
+                result += String.fromCharCode((c.charCodeAt(0) + key.toLocaleLowerCase().charCodeAt(j) - 2 * 97) % 26 + 97);
             }
         } else {
             result += c;
@@ -83,9 +83,9 @@ function vignereDecrypt(string, key) {
         const c = string.charAt(i);
         if (isLetter(c)) {
             if (isUpperCase(c)) {
-                result += String.fromCharCode(90 - (25 - (c.charCodeAt(0) - key.toUpperCase().charCodeAt(j))) % 26);
+                result += String.fromCharCode(90 - (25 - (c.charCodeAt(0) - key.toLocaleUpperCase().charCodeAt(j))) % 26);
             } else {
-                result += String.fromCharCode(122 - (25 - (c.charCodeAt(0) - key.toLowerCase().charCodeAt(j))) % 26);
+                result += String.fromCharCode(122 - (25 - (c.charCodeAt(0) - key.toLocaleLowerCase().charCodeAt(j))) % 26);
             }
         } else {
             result += c;

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -1,9 +1,14 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
-function shiftHexString(string, shiftValue) {
-    return hexToString(string).split("").map(c => 
-            ord(c) + parseInt(shiftValue)
-        ).join(" ");
+function shiftHexString(string, shiftValue, delimiter) {
+    let validHex = /[0-9A-Fa-f]+$/g;
+    if(validHex.test(string)) {
+        return hexToString(string, delimiter).split("").map(c => 
+            (ord(c) + parseInt(shiftValue)).toString(16)
+        ).join(delimiter);
+    } else {
+        throw Error("Hexadecimal contains invalid characters");
+    }
 }
 
 // Reverse Hex nibbles
@@ -18,6 +23,7 @@ const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
     let shiftValue = document.getElementById("shiftValue");
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -34,11 +40,11 @@ shiftButton.addEventListener("click", function() {
         return false;
     }
 
-    document.getElementById("text-tab-pane").textContent = decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value));
-    document.getElementById("binary-tab-pane").textContent = stringToBinary(decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value)));
-    document.getElementById("hex-tab-pane").textContent = stringToHex(decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value)));
-    document.getElementById("base64-tab-pane").textContent = stringToBase64(decimalToString(shiftHexString(shiftString.value.trim(), shiftValue.value)));
-    document.getElementById("decimal-tab-pane").textContent =  shiftHexString(shiftString.value.trim(), shiftValue.value);
+    document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
+    document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
+    document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("decimal-tab-pane").textContent =  string2Dec(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
 });
 
 // Reverse Hex

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -40,6 +40,13 @@ shiftButton.addEventListener("click", function() {
         return false;
     }
 
+    try {
+        shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
+    } catch (e) {
+        showToast("Error", `An error occured trying to shift the hex string: ${e.message}`, "danger");
+        return;
+    }
+
     document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
     document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
     document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -46,7 +46,7 @@ function morseToString(string) {
 // Convert to Morse
 function stringToMorse(string) {
     return string
-            .toUpperCase()
+            .toLocaleUpperCase()
             .split(" ")
             .map(word => word
                         .split("") // get character code,

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -9,7 +9,7 @@ function binaryToString(string) {
             ...string.split(" ").map(bin => parseInt(bin, 2))
         );
     } else {
-        throw Error("Binary is not valid");
+        throw Error("Not a valid Binary string");
     }
 }
 
@@ -21,7 +21,7 @@ function base64ToString(string) {
             return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
         }).join(""));
     } catch (e) {
-        throw Error("not a valid Base64 string");
+        throw Error("Not a valid Base64 string");
     }
 }
 

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -25,10 +25,10 @@ function isLetter(string) {
 
 // Check is character/string is uppercase or lowecase
 function isUpperCase(string) {
-    if (string === string.toUpperCase()) {
+    if (string === string.toLocaleUpperCase()) {
         return true;
     }
-    if (string === string.toLowerCase()) {
+    if (string === string.toLocaleLowerCase()) {
         return false;
     }
 }

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -69,18 +69,23 @@ function stringToHex(string, delimiter) { // UTF-8
 
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
-function hexToString(string) {
-    try {
-        return decodeURIComponent(
-            string.replace(/\s|-|:|\.|\!|,|(0x)/g, "") // remove spaces
-            .replace(/[0-9a-f]{2}/g, "%$&") // add "%" before each 2 characters
-        );
-    } catch (e) {
-        throw Error("Hexadecimal is not valid");
+function hexToString(string, delimiter) {
+    let validHex = /[0-9A-Fa-f]+$/g;
+
+    if (validHex.test(string)) {
+        let hexDelimiter = delimiter ? delimiter : document.getElementById("hexDelimiter").value;
+        const hex = Array.from(string.trim().split(hexDelimiter));
+        const len = hex.length;
+        let hexArray = [];
+
+        for (let i = 0; i < len; i++) {
+            hexArray.push(String.fromCharCode(parseInt(hex[i], 16)));
+        }
+        return hexArray.join("");
+    } else {
+        throw Error("Hexadecimal contains invalid characters");
     }
 }
-// Previous method: https://stackoverflow.com/a/69420340/3172872
-// return decodeURIComponent("%" + string.replace(/ /g, "").match(/.{1,2}/g).join("%"));
 
 // Convert to Base64
 // https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings

--- a/assets/js/tools.js
+++ b/assets/js/tools.js
@@ -1,6 +1,6 @@
 // Remove spaces
 function stripSpaces(string) {
-    return string.replace(/ /gi, "");
+    return string.replace(/ /g, "");
 }
 
 // Uppercase string
@@ -21,7 +21,7 @@ function numbersOnly(string, preserveSpaces) {
 
 // Letters only
 function lettersOnly(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[^a-z ]/gi : /[^a-z]/gi;
+    let regex = preserveSpaces === true ? /[^A-Za-z ]/g : /[^A-Za-z]/g;
     return string.replace(regex, "");
 }
 
@@ -39,13 +39,13 @@ function lettersOnlyLow(string, preserveSpaces) {
 
 // Remove special characters
 function stripSpecialChars(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[^a-z0-9 ]/gi : /[^a-z0-9]/gi;
+    let regex = preserveSpaces === true ? /[^0-9A-Za-z ]/g : /[^0-9A-Za-z]/g;
     return string.replace(regex, "");
 }
 
 // Remove all letters
 function stripLetters(string) {
-    return string.replace(/[a-z]/gi, "");
+    return string.replace(/[A-Za-z]/g, "");
 }
 
 // Remove all numbers
@@ -55,18 +55,18 @@ function stripNumbers(string) {
 
 // Special characters only
 function specialCharsOnly(string, preserveSpaces) {
-    let regex = preserveSpaces === true ? /[a-z0-9]/gi : /[a-z0-9 ]/gi;
+    let regex = preserveSpaces === true ? /[0-9A-Za-z]/g : /[0-9A-Za-z ]/g;
     return string.replace(regex, "");
 }
 
 // URL encode
 function urlEncode(string) {
-    return encodeURIComponent(string).replace(/%20/gi, "+");
+    return encodeURIComponent(string).replace(/%20/g, "+");
 }
 
 // URL decode
 function urlDecode(string) {
-    return decodeURIComponent(string).replace(/\+/gi, " ");
+    return decodeURIComponent(string).replace(/\+/g, " ");
 }
 
 // Convert letters to their alphabet number: A = 1, B = 2, Z = 26

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convrtrjs",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "A simple JavaScript based tool to quickly convert text between different formats",
   "tagline": "For everlost and Grollow!",
   "main": "index.html",


### PR DESCRIPTION
## Changes
- Reworked functionality to convert strings to hex, allowing any valid hex characters to be converted
- Reworked functionality of hex shifter in the same manner, also surfacing an error message now on invalid hex
- Updated some regex matches to potentially be a bit more performant (dropping the reliance on the case-insensitive flag)
- Switch to locale case when doing transforms with casing

## Bug fixes
- Shift hex now correctly handles the delimiter dropdown when converting