### PR TITLE
V 1.10.6

### DIFF
--- a/_includes/components/delimiter.liquid
+++ b/_includes/components/delimiter.liquid
@@ -5,4 +5,5 @@
     <option value=",">Comma</option>
     <option value="\x">Slash x (\x)</option>
     <option value="0x">Zero x (0x)</option>
+    <option value="">No delimiter</option>
 </select>

--- a/_includes/components/delimiter.liquid
+++ b/_includes/components/delimiter.liquid
@@ -1,0 +1,8 @@
+<select class="form-select {% if page-id == "home" %}form-select-sm mx-2 ms-auto {%endif %}w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter">
+    <option value=" " selected="">Space</option>
+    <option value="-">Hyphen</option>
+    <option value=":">Colon</option>
+    <option value=",">Comma</option>
+    <option value="\x">Slash x (\x)</option>
+    <option value="0x">Zero x (0x)</option>
+</select>

--- a/_includes/components/delimiter.liquid
+++ b/_includes/components/delimiter.liquid
@@ -1,4 +1,4 @@
-<select class="form-select {% if page-id == "home" %}form-select-sm mx-2 ms-auto {%endif %}w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter">
+<select class="form-select {% if page-id == "home" %}form-select-sm mx-2 ms-auto {%endif %}w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter" id="{{ hexDelimiter }}">
     <option value=" " selected="">Space</option>
     <option value="-">Hyphen</option>
     <option value=":">Colon</option>

--- a/_includes/partials/hex/reversehex.liquid
+++ b/_includes/partials/hex/reversehex.liquid
@@ -1,3 +1,4 @@
+{% assign hexDelimiter = "reverseHexDelimiter" %}
 <section id="reverseHex" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading mb-4">

--- a/_includes/partials/hex/reversehex.liquid
+++ b/_includes/partials/hex/reversehex.liquid
@@ -14,7 +14,10 @@
             </div>
             <hr>
             <p class="px-2">
-                Unlike reversing the entire string, this reverses each individual hex string. <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">74 65 73 74</code> [test] becomes <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">47 56 37 47</code>.
+                Unlike reversing the entire string, this reverses each individual hex byte. <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">74 65 73 74</code> [test] becomes <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">47 56 37 47</code>.
+            </p>
+            <p class="px-2">
+                The dropdown allows you to select a delimiter, which is how your hex values are split up and joined together. The default is a space, you can select no delimiter if your hex contains no spaces.
             </p>
         </div>
         <div class="collapse" id="reverseHexCollapse">

--- a/_includes/partials/hex/reversehex.liquid
+++ b/_includes/partials/hex/reversehex.liquid
@@ -25,12 +25,9 @@
                     </div>
                     <div class="card-footer py-3">
                         <div class="d-flex justify-content-start align-items-center">
-                            <button type="button" class="btn btn-md btn-convrtr" id="reverseHexDecode" title="Reverse hex nibbles">Reverse</button>
-                            <div class="btn-group ms-auto">
-                                <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>
-                                <button type="button" class="btn btn-md btn-light btn-copy" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Copy to clipboard" data-bs-original-title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
-                                <button type="button" class="btn btn-md btn-light btn-download" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Download" data-bs-original-title="Download"><i class="bi bi-download"></i></button>
-                            </div>
+                            <button type="button" class="btn btn-md btn-convrtr me-2" id="reverseHexDecode" title="Reverse hex nibbles">Reverse</button>
+                            {% include "components/delimiter" %}
+                            {% include "components/select-copy-dl" %}
                         </div>
                         <hr />
                         <div id="reverseHexResults" class="data-to-copy active"></div>

--- a/_includes/partials/hex/shift.liquid
+++ b/_includes/partials/hex/shift.liquid
@@ -15,7 +15,9 @@
             <hr>
             <p class="px-2">
                 Lazy shift a hexadecimal string up or down: <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">54 65 73 74</code> [test] becomes <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">55 66 74 75</code> [uftu] when shifted 1 to the right (+1) or <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">53 64 72 73</code> [Sdrs] when shifted 1 to the left. 
-                Supports any delimiter is available in the delimiter dropdown, the default is always a space. 
+            </p>
+            <p class="px-2">
+                The dropdown allows you to select a delimiter, which is how your hex values are split up and joined together. The default is a space, you can select no delimiter if your hex contains no spaces.
             </p>
         </div>
         <div class="collapse show" id="shiftHexCollapse">

--- a/_includes/partials/hex/shift.liquid
+++ b/_includes/partials/hex/shift.liquid
@@ -35,19 +35,8 @@
                                     </div>
                                 </div>
                                 <div class="col d-flex flex-fill justify-content-start mb-2">
-                                    <select id="hexDelimiter" class="form-select w-auto" aria-label="Change Hexadecimal delimiter">
-                                        <option value=" " selected="">Space</option>
-                                        <option value="-">Hyphen</option>
-                                        <option value=":">Colon</option>
-                                        <option value=",">Comma</option>
-                                        <option value="\x">Slash x (\x)</option>
-                                        <option value="0x">Zero x (0x)</option>
-                                    </select>
-                                    <div class="btn-group ms-auto">
-                                        <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>
-                                        <button type="button" class="btn btn-md btn-light btn-copy" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Copy to clipboard" data-bs-original-title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
-                                        <button type="button" class="btn btn-md btn-light btn-download" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Download" data-bs-original-title="Download"><i class="bi bi-download"></i></button>
-                                    </div>
+                                    {% include "components/delimiter" %}
+                                    {% include "components/select-copy-dl" %}
                                 </div>
                             </div>
                         </div>

--- a/_includes/partials/hex/shift.liquid
+++ b/_includes/partials/hex/shift.liquid
@@ -1,3 +1,4 @@
+{% assign hexDelimiter = "shiftHexDelimiter" %}
 <section id="shift" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading mb-4">

--- a/_includes/partials/home/convrtrs.liquid
+++ b/_includes/partials/home/convrtrs.liquid
@@ -1,4 +1,3 @@
-{% assign hexDelimiter = "hexDelimiter" %}
 <section id="convrtrs" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading">

--- a/_includes/partials/home/convrtrs.liquid
+++ b/_includes/partials/home/convrtrs.liquid
@@ -1,3 +1,4 @@
+{% assign hexDelimiter = "hexDelimiter" %}
 <section id="convrtrs" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading">
@@ -58,14 +59,7 @@
                                     </label>
                                 </span>
                                 {% if tool.id == "hex" %}
-                                <select id="hexDelimiter" class="form-select form-select-sm mx-2 ms-auto w-auto" aria-label="Change Hexadecimal delimiter">
-                                    <option value=" " selected="">Space</option>
-                                    <option value="-">Hyphen</option>
-                                    <option value=":">Colon</option>
-                                    <option value=",">Comma</option>
-                                    <option value="\x">Slash x (\x)</option>
-                                    <option value="0x">Zero x (0x)</option>
-                                </select>
+                                {% include "components/delimiter" %}
                                 {% endif %}
                                 {% if tool.id == "morsenary" %}
                                 <select id="morsenarySetting" class="form-select form-select-sm mx-2 ms-auto w-auto" aria-label="Change Binary substitution">

--- a/_includes/partials/home/convrtrs.liquid
+++ b/_includes/partials/home/convrtrs.liquid
@@ -1,3 +1,4 @@
+{% assign hexDelimiter = "hexDelimiter" %}
 <section id="convrtrs" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading">

--- a/_site/404.html
+++ b/_site/404.html
@@ -149,8 +149,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.5</small>
+            <abbr title="Release version: v1.10.6" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.6</small>
             </abbr>
         </div>
     </div>

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -1,7 +1,7 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    let validHex = /[0-9A-Fa-f]+$/g;
+    const validHex = /[0-9A-Fa-f]+$/g;
     if(validHex.test(string)) {
         return hexToString(string, delimiter).split("").map(c => 
             (ord(c) + parseInt(shiftValue)).toString(16)
@@ -11,12 +11,26 @@ function shiftHexString(string, shiftValue, delimiter) {
     }
 }
 
-// Reverse Hex nibbles
+// Reverse Hex
+// Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
 function reverseHex(string) {
     return stringToHex(hexToString(string), " ").split(" ").map(c => 
             reverseString(c)
            ).join(" ");
 }
+
+// Reverse Hex nibbles
+// Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
+function reverseHexNibbles(string) {
+    const nibbles = [];
+    const strLength = string.length;
+    for (let i = 0; i < strLength; i += 2) {
+        const nibble = parseInt(string.substr(i, 2), 16);
+        nibbles.push(nibble);
+    }
+    return nibbles.reverse().map(nibble => nibble.toString(16)).join("");
+}
+
 
 // Shift Hex
 const shiftButton = document.getElementById("shiftDecode");

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -7,7 +7,7 @@ function shiftHexString(string, shiftValue, delimiter) {
             (ord(c) + parseInt(shiftValue)).toString(16)
         ).join(delimiter);
     } else {
-        throw Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters");
     }
 }
 

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -1,7 +1,7 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
+    
     if(validHex.test(string)) {
         return hexToString(string, delimiter).split("").map(c => 
             (ord(c) + parseInt(shiftValue)).toString(16)
@@ -21,14 +21,12 @@ function reverseHex(string, delimiter) {
 
 // Reverse Hex nibbles
 // Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
-function reverseHexNibbles(string) {
-    const nibbles = [];
-    const strLength = string.length;
-    for (let i = 0; i < strLength; i += 2) {
-        const nibble = parseInt(string.substr(i, 2), 16);
-        nibbles.push(nibble);
+function reverseHexNibbles(string, delimiter) {
+    if(validHex.test(string)) {
+        return string.split(delimiter).reverse().join(delimiter);
+    } else {
+        throw new Error("Hexadecimal contains invalid characters");
     }
-    return nibbles.reverse().map(nibble => nibble.toString(16)).join("");
 }
 
 

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -1,7 +1,8 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    
+    const validHex = /[0-9A-Fa-f]+$/g;
+
     if(validHex.test(string)) {
         return hexToString(string, delimiter).split("").map(c => 
             (ord(c) + parseInt(shiftValue)).toString(16)
@@ -14,14 +15,22 @@ function shiftHexString(string, shiftValue, delimiter) {
 // Reverse Hex
 // Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
 function reverseHex(string, delimiter) {
-    return string.split(delimiter).map(c => 
-              reverseString(c)
-           ).join(delimiter);
+    const validHex = /[0-9A-Fa-f]+$/g;
+
+    if(validHex.test(string)) {
+        return string.split(delimiter).map((c) => 
+            reverseString(c)
+        ).join(delimiter);
+    } else {
+        throw new Error("Hexadecimal contains invalid characters");
+    }
 }
 
 // Reverse Hex nibbles
 // Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
 function reverseHexNibbles(string, delimiter) {
+    const validHex = /[0-9A-Fa-f]+$/g;
+
     if(validHex.test(string)) {
         return string.split(delimiter).reverse().join(delimiter);
     } else {
@@ -29,11 +38,12 @@ function reverseHexNibbles(string, delimiter) {
     }
 }
 
-
 // Shift Hex
 const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
+    let shiftValue = document.getElementById("shiftValue");
+    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -57,19 +67,18 @@ shiftButton.addEventListener("click", function() {
         return;
     }
 
-    let shiftValue = document.getElementById("shiftValue");
-    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
     document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
     document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
     document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
     document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
-    document.getElementById("decimal-tab-pane").textContent =  string2Dec(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("decimal-tab-pane").textContent =  stringToDecimal(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
 });
 
 // Reverse Hex
 const reverseHexButton = document.getElementById("reverseHexDecode");
 reverseHexButton.addEventListener("click", function() {
     const reverseHexString = document.getElementById("reverseHexText");
+    let hexDelimiter = document.getElementById("reverseHexDelimiter").value;
 
     if(!emptyContainerCheck(reverseHexString.value, reverseHexString)) {
         return false;
@@ -78,6 +87,11 @@ reverseHexButton.addEventListener("click", function() {
         return false;
     }
 
-    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
-    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value, hexDelimiter);
+    try {
+        reverseHex(reverseHexString.value.trim(), hexDelimiter);
+    } catch (e) {
+        showToast("Error", `An error occured trying to reverse the hex string: ${e.message}`, "danger");
+        return;
+    }
+    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value.trim(), hexDelimiter);
 });

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -13,10 +13,10 @@ function shiftHexString(string, shiftValue, delimiter) {
 
 // Reverse Hex
 // Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
-function reverseHex(string) {
-    return stringToHex(hexToString(string), " ").split(" ").map(c => 
-            reverseString(c)
-           ).join(" ");
+function reverseHex(string, delimiter) {
+    return string.split(delimiter).map(c => 
+              reverseString(c)
+           ).join(delimiter);
 }
 
 // Reverse Hex nibbles
@@ -36,8 +36,6 @@ function reverseHexNibbles(string) {
 const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
-    let shiftValue = document.getElementById("shiftValue");
-    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -61,6 +59,8 @@ shiftButton.addEventListener("click", function() {
         return;
     }
 
+    let shiftValue = document.getElementById("shiftValue");
+    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
     document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
     document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
     document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
@@ -80,5 +80,6 @@ reverseHexButton.addEventListener("click", function() {
         return false;
     }
 
-    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value);
+    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
+    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value, hexDelimiter);
 });

--- a/_site/assets/js/hex/hex.js
+++ b/_site/assets/js/hex/hex.js
@@ -1,40 +1,36 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if(validHex.test(string)) {
-        return hexToString(string, delimiter).split("").map(c => 
-            (ord(c) + parseInt(shiftValue)).toString(16)
-        ).join(delimiter);
+    if(isValidHex(string, delimiter)) {
+        return hexToString(string, delimiter).split("").map(c => (ord(c) + parseInt(shiftValue)).toString(16)).join(delimiter);
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 
 // Reverse Hex
 // Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
 function reverseHex(string, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if(validHex.test(string)) {
-        return string.split(delimiter).map((c) => 
-            reverseString(c)
-        ).join(delimiter);
+    let reversedString;
+    if(isValidHex(string, delimiter)) {
+        if(delimiter === "") {
+            reversedString = stringToArray(string, 2).map((c) => reverseString(c)).join(delimiter);
+        } else {
+            reversedString = string.split(delimiter).map((c) => reverseString(c)).join(delimiter);
+        }
+        return reversedString;
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 
 // Reverse Hex nibbles
 // Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
 function reverseHexNibbles(string, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if(validHex.test(string)) {
+    if(isValidHex(string, delimiter)) {
         return string.split(delimiter).reverse().join(delimiter);
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 
@@ -43,7 +39,7 @@ const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
     let shiftValue = document.getElementById("shiftValue");
-    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
+    let shiftHexDelimiter = document.getElementById("shiftHexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -61,24 +57,24 @@ shiftButton.addEventListener("click", function() {
     }
 
     try {
-        shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
+        shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter);
     } catch (e) {
         showToast("Error", `An error occured trying to shift the hex string: ${e.message}`, "danger");
         return;
     }
 
-    document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
-    document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
-    document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
-    document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
-    document.getElementById("decimal-tab-pane").textContent =  stringToDecimal(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter);
+    document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter));
+    document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter);
+    document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter));
+    document.getElementById("decimal-tab-pane").textContent =  stringToDecimal(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter));
 });
 
 // Reverse Hex
 const reverseHexButton = document.getElementById("reverseHexDecode");
 reverseHexButton.addEventListener("click", function() {
     const reverseHexString = document.getElementById("reverseHexText");
-    let hexDelimiter = document.getElementById("reverseHexDelimiter").value;
+    let reverseHexDelimiter = document.getElementById("reverseHexDelimiter").value;
 
     if(!emptyContainerCheck(reverseHexString.value, reverseHexString)) {
         return false;
@@ -88,10 +84,10 @@ reverseHexButton.addEventListener("click", function() {
     }
 
     try {
-        reverseHex(reverseHexString.value.trim(), hexDelimiter);
+        reverseHex(reverseHexString.value.trim(), reverseHexDelimiter);
     } catch (e) {
         showToast("Error", `An error occured trying to reverse the hex string: ${e.message}`, "danger");
         return;
     }
-    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value.trim(), hexDelimiter);
+    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value.trim(), reverseHexDelimiter);
 });

--- a/_site/assets/js/home/convrtrs.js
+++ b/_site/assets/js/home/convrtrs.js
@@ -1,4 +1,6 @@
 // Make it so
+let hexDelimiter = document.getElementById("hexDelimiter").value;
+
 document.getElementById("encode").addEventListener("click", function() {
     const container = this.closest(".card-body").querySelector("textarea");
     const data = container.value;
@@ -11,7 +13,7 @@ document.getElementById("encode").addEventListener("click", function() {
     }
 
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(data);
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(data);
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(data, hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(data);
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(data);
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
@@ -41,7 +43,7 @@ document.getElementById("binaryDecode").addEventListener("click", function() {
         return;
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = binaryToString(data);
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(binaryToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(binaryToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(binaryToString(data));
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(binaryToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
@@ -65,19 +67,19 @@ document.getElementById("hexDecode").addEventListener("click", function() {
     }
 
     try {
-        hexToString(data);
+        hexToString(data, hexDelimiter);
     } catch (e) {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
-    document.getElementById("convrtr-text").querySelector("textarea").value = hexToString(data);
-    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data));
-    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data));
-    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data));
+    document.getElementById("convrtr-text").querySelector("textarea").value = hexToString(data, hexDelimiter);
+    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data), hexDelimiter);
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(data);
-    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data));
-    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data));
+    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data), hexDelimiter);
 });
 
 
@@ -102,7 +104,7 @@ document.getElementById("b64Decode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = base64ToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(base64ToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(base64ToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(base64ToString(data), hexDelimiter);
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(base64ToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = "";
@@ -132,7 +134,7 @@ document.getElementById("decDecode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = decimalToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(decimalToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(decimalToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(decimalToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(decimalToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(data);
@@ -160,9 +162,12 @@ document.getElementById("revDecode").addEventListener("click", function() {
         showToast("Error", "An error occured trying to decode the data.", "danger");
         return;
     }
+
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
+    console.log("Delimiter", hexDelimiter);
     document.getElementById("convrtr-text").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = reverseString(stringToBinary(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = reverseString(stringToBase64(data));
     document.getElementById("convrtr-decimal").querySelector("textarea").value = reverseString(stringToDecimal(data));
     document.getElementById("convrtr-rot13").querySelector("textarea").value = reverseString(rot13(data));
@@ -192,7 +197,7 @@ document.getElementById("rot13Decode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = rot13(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(rot13(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(rot13(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(rot13(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(rot13(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(rot13(data));
@@ -222,7 +227,7 @@ document.getElementById("morseDecode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = morseToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morseToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morseToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morseToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(morseToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(morseToString(data));
@@ -252,7 +257,7 @@ document.getElementById("mrsnryDecode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = morsenaryToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morsenaryToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morsenaryToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morsenaryToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(morsenaryToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = "";

--- a/_site/assets/js/home/convrtrs.js
+++ b/_site/assets/js/home/convrtrs.js
@@ -1,9 +1,8 @@
 // Make it so
-let hexDelimiter = document.getElementById("hexDelimiter").value;
-
 document.getElementById("encode").addEventListener("click", function() {
     const container = this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -28,6 +27,7 @@ document.getElementById("binaryDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -42,6 +42,7 @@ document.getElementById("binaryDecode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = binaryToString(data);
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(binaryToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(binaryToString(data));
@@ -58,6 +59,7 @@ document.getElementById("hexDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -72,14 +74,15 @@ document.getElementById("hexDecode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = hexToString(data, hexDelimiter);
-    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data), hexDelimiter);
-    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data), hexDelimiter);
-    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data, hexDelimiter));
+    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data, hexDelimiter));
+    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data, hexDelimiter));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(data);
-    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data), hexDelimiter);
-    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data, hexDelimiter));
+    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data, hexDelimiter));
 });
 
 
@@ -88,6 +91,7 @@ document.getElementById("b64Decode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -102,6 +106,7 @@ document.getElementById("b64Decode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = base64ToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(base64ToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(base64ToString(data), hexDelimiter);
@@ -118,6 +123,7 @@ document.getElementById("decDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -132,6 +138,7 @@ document.getElementById("decDecode").addEventListener("click", function() {
         showToast("Error", "An error occured trying to decode the data.", "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = decimalToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(decimalToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(decimalToString(data), hexDelimiter);
@@ -148,6 +155,7 @@ document.getElementById("revDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -163,11 +171,9 @@ document.getElementById("revDecode").addEventListener("click", function() {
         return;
     }
 
-    let hexDelimiter = document.getElementById("hexDelimiter").value;
-    console.log("Delimiter", hexDelimiter);
     document.getElementById("convrtr-text").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = reverseString(stringToBinary(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data), hexDelimiter);
+    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data, hexDelimiter));
     document.getElementById("convrtr-base64").querySelector("textarea").value = reverseString(stringToBase64(data));
     document.getElementById("convrtr-decimal").querySelector("textarea").value = reverseString(stringToDecimal(data));
     document.getElementById("convrtr-rot13").querySelector("textarea").value = reverseString(rot13(data));
@@ -181,6 +187,7 @@ document.getElementById("rot13Decode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -195,6 +202,7 @@ document.getElementById("rot13Decode").addEventListener("click", function() {
         showToast("Error", "An error occured trying to decode the data.", "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = rot13(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(rot13(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(rot13(data), hexDelimiter);
@@ -211,6 +219,7 @@ document.getElementById("morseDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -225,6 +234,7 @@ document.getElementById("morseDecode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = morseToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morseToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morseToString(data), hexDelimiter);
@@ -241,6 +251,7 @@ document.getElementById("mrsnryDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -255,6 +266,7 @@ document.getElementById("mrsnryDecode").addEventListener("click", function() {
         showToast("Error",`An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = morsenaryToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morsenaryToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morsenaryToString(data), hexDelimiter);

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -29,6 +29,15 @@ function base64ToString(string) {
     } catch (e) {
         throw Error("Not a valid Base64 string");
     }
+
+    // try {
+    //     const decodedString = atob(base64String);
+    //     const utf8String = decodeURIComponent(encodeURIComponent(decodedString));
+    //     return utf8String;
+    // } catch (error) {
+    //     console.error("Error decoding Base64 string:", error);
+    //     return null;
+    // }
 }
 
 // Morse code to String

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -1,17 +1,23 @@
 // Decode Binary
+function isValidBinaryLength(string) {
+    return string.length % 8 === 0;
+}
+
 function binaryToString(string) {
-    let stringReplacement = string.replace(/[\D2-9]/g,""); // Strip everything but 1s and 0s
-    string = string.replace(/[^w\s10]/g); // Same, but preserve spaces
-    // Probably better ways to handle this, but make sure the string is divible by 8
-    // If it's not, it's probably an incomplete binary string
-    if((stringReplacement.length > 0 && stringReplacement.length % 8) === 0) {
-        return String.fromCharCode(
-            ...string.split(" ").map(bin => parseInt(bin, 2))
-        );
+    if(isValidBinaryLength(string)) {
+        string = string.replace(/[^10\s]/g, "");
+
+        let charCodes = string.split(" ").map(bin => {
+            bin = bin.padStart(8, "0");
+            return parseInt(bin, 2);
+        });
+
+        return String.fromCharCode(...charCodes);
     } else {
         throw Error("Not a valid Binary string");
     }
 }
+
 
 // Decode Base64
 function base64ToString(string) {

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -60,15 +60,16 @@ function stringToMorse(string) {
 // Convert to Morsenary
 function stringToMorsenary(string) {
     let morsenarySetting = document.getElementById("morsenarySetting").value;
-    return morsenarySetting === "default" ? stringToBinary(string).replace(/ /g,"").replaceAll("0",".").replaceAll("1","-") :
-                                        stringToBinary(string).replace(/ /g,"").replaceAll("1",".").replaceAll("0","-");
+    return morsenarySetting === "default" ? stringToBinary(string).replace(/ /g, '').replace(/[01]/g, (match) => (match === '1' ? '-' : '.')) :
+    stringToBinary(string).replace(/ /g, '').replace(/[01]/g, (match) => (match === '1' ? '.' : '-'));
 }
+
 
 // Decode Morsenary to String
 function morsenaryToString(string) {
     if(/^[ /.-]*$/.test(string)) {
         let morsenarySetting = document.getElementById("morsenarySetting").value;
-        string = morsenarySetting === "default" ? string.replaceAll(".","0").replaceAll("-","1") : string.replaceAll(".","1").replaceAll("-","0");
+        string = morsenarySetting === "default" ? string.replace(/[.-]/g, (match) => (match === '.' ? '0' : '1')) : string.replace(/[.-]/g, (match) => (match === '.' ? '1' : '0'));
         return binaryToString(splitString(string, 8));
     } else {
        throw Error("Morsenary contains invalid characters");

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -162,7 +162,6 @@ function styledArrayFrequencies(data) {
 let hexDelimiterSelect = document.getElementById("hexDelimiter");
 hexDelimiterSelect.addEventListener("change", function() {
     let hexData = document.getElementById("form-hex").value;
-    console.log(hexData);
     if(hexData === "") {
         return;
     }

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -14,7 +14,7 @@ function binaryToString(string) {
 
         return String.fromCharCode(...charCodes);
     } else {
-        throw Error("Not a valid Binary string");
+        throw new Error("Not a valid Binary string");
     }
 }
 
@@ -54,7 +54,7 @@ function morseToString(string) {
             .join(" ")
             .trim();
     } else {
-        throw Error("Morse code contains invalid characters");
+        throw new Error("Morse code contains invalid characters");
     }
 }
 
@@ -87,7 +87,7 @@ function morsenaryToString(string) {
         string = morsenarySetting === "default" ? string.replace(/[.-]/g, (match) => (match === '.' ? '0' : '1')) : string.replace(/[.-]/g, (match) => (match === '.' ? '1' : '0'));
         return binaryToString(splitString(string, 8));
     } else {
-       throw Error("Morsenary contains invalid characters");
+       throw new Error("Morsenary contains invalid characters");
     }
 }
 

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -22,22 +22,14 @@ function binaryToString(string) {
 // Decode Base64
 function base64ToString(string) {
     // Going backwards: from bytestream, to percent-encoding, to original string.
+    // https://stackoverflow.com/a/30106551/3172872
     try {
         return decodeURIComponent(atob(string).split("").map(function(c) {
             return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
         }).join(""));
     } catch (e) {
-        throw Error("Not a valid Base64 string");
+        throw new Error("Not a valid Base64 string");
     }
-
-    // try {
-    //     const decodedString = atob(base64String);
-    //     const utf8String = decodeURIComponent(encodeURIComponent(decodedString));
-    //     return utf8String;
-    // } catch (error) {
-    //     console.error("Error decoding Base64 string:", error);
-    //     return null;
-    // }
 }
 
 // Morse code to String

--- a/_site/assets/js/home/home.js
+++ b/_site/assets/js/home/home.js
@@ -158,17 +158,18 @@ function styledArrayFrequencies(data) {
     return result;
 }
 
-// Re-code Hex on delimeter change
+// Re-code Hex on delimiter change
 let hexDelimiterSelect = document.getElementById("hexDelimiter");
 hexDelimiterSelect.addEventListener("change", function() {
     let hexData = document.getElementById("form-hex").value;
+    console.log(hexData);
     if(hexData === "") {
         return;
     }
     document.getElementById("encode").click();
 });
 
-// Re-code Morsenary on delimeter change
+// Re-code Morsenary on delimiter change
 let morsenarySelect = document.getElementById("morsenarySetting");
 morsenarySelect.addEventListener("change", function() {
     let morsenaryData = document.getElementById("form-morsenary").value;

--- a/_site/assets/js/toolkit.js
+++ b/_site/assets/js/toolkit.js
@@ -1,6 +1,7 @@
 const alphabet	= " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 const alphaFlip	= " ⱯQƆPƎℲפHIſʞ˥WNOԀQɹS┴∩ΛMX⅄Zɐqɔpǝɟƃɥıɾʞןɯuodbɹsʇnʌʍxʎz";
 const alphaRot  = " NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm";
+const validHex = /[0-9A-Fa-f]+$/g;
 
 // Morse map
 const morseTextDict = {  
@@ -70,8 +71,6 @@ function stringToHex(string, delimiter) { // UTF-8
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
 function hexToString(string, delimiter) {
-    let validHex = /[0-9A-Fa-f]+$/g;
-
     if (validHex.test(string)) {
         const hex = Array.from(string.trim().split(delimiter));
         const len = hex.length;

--- a/_site/assets/js/toolkit.js
+++ b/_site/assets/js/toolkit.js
@@ -55,10 +55,15 @@ function stringToBinary(string) {
     return Array.from(string).map(c => c.charCodeAt().toString(2).padStart(8,0)).join(" ");
 }
 
+function isValidHex(string, delimiter) {
+    const validHex = /^[0-9A-Fa-f]+$/g;
+    let hexTest = string.replaceAll(delimiter, "");
+    return validHex.test(hexTest);
+}
+
 // Convert to Hex
 // https://stackoverflow.com/a/69420340/3172872
 function stringToHex(string, delimiter) { // UTF-8
-    console.log(delimiter);
     let returnValue = Array.from(string).map(c => 
         c.charCodeAt(0) < 128 ? c.charCodeAt(0).toString(16).padStart(2, '0') : 
         encodeURIComponent(c).replace(/\%/g,"").toLowerCase()
@@ -70,19 +75,24 @@ function stringToHex(string, delimiter) { // UTF-8
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
 function hexToString(string, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if (validHex.test(string)) {
-        const hex = Array.from(string.trim().split(delimiter));
-        const len = hex.length;
+    if (isValidHex(string, delimiter)) {
         let hexArray = [];
-
-        for (let i = 0; i < len; i++) {
-            hexArray.push(String.fromCharCode(parseInt(hex[i], 16)));
+        const len = string.length;
+        if(delimiter === "") {
+            for (let i = 0; i < len; i += 2) {
+                const chunk = string.slice(i, i + 2);
+                hexArray.push(String.fromCharCode(parseInt(chunk, 16)));
+            }
+        } else {
+            const hex = Array.from(string.trim().split(delimiter));
+            const len = hex.length;
+            for (let i = 0; i < len; i++) {
+                hexArray.push(String.fromCharCode(parseInt(hex[i], 16)));
+            }
         }
         return hexArray.join("");
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 

--- a/_site/assets/js/toolkit.js
+++ b/_site/assets/js/toolkit.js
@@ -1,7 +1,6 @@
 const alphabet	= " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 const alphaFlip	= " ⱯQƆPƎℲפHIſʞ˥WNOԀQɹS┴∩ΛMX⅄Zɐqɔpǝɟƃɥıɾʞןɯuodbɹsʇnʌʍxʎz";
 const alphaRot  = " NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm";
-const validHex = /[0-9A-Fa-f]+$/g;
 
 // Morse map
 const morseTextDict = {  
@@ -71,6 +70,8 @@ function stringToHex(string, delimiter) { // UTF-8
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
 function hexToString(string, delimiter) {
+    const validHex = /[0-9A-Fa-f]+$/g;
+
     if (validHex.test(string)) {
         const hex = Array.from(string.trim().split(delimiter));
         const len = hex.length;

--- a/_site/assets/js/toolkit.js
+++ b/_site/assets/js/toolkit.js
@@ -58,13 +58,13 @@ function stringToBinary(string) {
 // Convert to Hex
 // https://stackoverflow.com/a/69420340/3172872
 function stringToHex(string, delimiter) { // UTF-8
-    let hexDelimiter = delimiter ? delimiter : document.getElementById("hexDelimiter").value;
+    console.log(delimiter);
     let returnValue = Array.from(string).map(c => 
         c.charCodeAt(0) < 128 ? c.charCodeAt(0).toString(16).padStart(2, '0') : 
         encodeURIComponent(c).replace(/\%/g,"").toLowerCase()
-    ).join(`${hexDelimiter}`);
+    ).join(`${delimiter}`);
 
-    return (hexDelimiter === "\\x" || hexDelimiter === "0x") ? hexDelimiter + returnValue : returnValue;
+    return (delimiter === "\\x" || delimiter === "0x") ? delimiter + returnValue : returnValue;
 }
 
 // Decode Hex to string
@@ -73,8 +73,7 @@ function hexToString(string, delimiter) {
     let validHex = /[0-9A-Fa-f]+$/g;
 
     if (validHex.test(string)) {
-        let hexDelimiter = delimiter ? delimiter : document.getElementById("hexDelimiter").value;
-        const hex = Array.from(string.trim().split(hexDelimiter));
+        const hex = Array.from(string.trim().split(delimiter));
         const len = hex.length;
         let hexArray = [];
 

--- a/_site/assets/js/toolkit.js
+++ b/_site/assets/js/toolkit.js
@@ -83,7 +83,7 @@ function hexToString(string, delimiter) {
         }
         return hexArray.join("");
     } else {
-        throw Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters");
     }
 }
 

--- a/_site/ciphers/index.html
+++ b/_site/ciphers/index.html
@@ -801,8 +801,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.5</small>
+            <abbr title="Release version: v1.10.6" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.6</small>
             </abbr>
         </div>
     </div>

--- a/_site/files/index.html
+++ b/_site/files/index.html
@@ -840,8 +840,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.5</small>
+            <abbr title="Release version: v1.10.6" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.6</small>
             </abbr>
         </div>
     </div>

--- a/_site/hex/index.html
+++ b/_site/hex/index.html
@@ -290,19 +290,19 @@
                                     </div>
                                 </div>
                                 <div class="col d-flex flex-fill justify-content-start mb-2">
-                                    <select id="hexDelimiter" class="form-select w-auto" aria-label="Change Hexadecimal delimiter">
-                                        <option value=" " selected="">Space</option>
-                                        <option value="-">Hyphen</option>
-                                        <option value=":">Colon</option>
-                                        <option value=",">Comma</option>
-                                        <option value="\x">Slash x (\x)</option>
-                                        <option value="0x">Zero x (0x)</option>
-                                    </select>
+                                    <select class="form-select w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter">
+    <option value=" " selected="">Space</option>
+    <option value="-">Hyphen</option>
+    <option value=":">Colon</option>
+    <option value=",">Comma</option>
+    <option value="\x">Slash x (\x)</option>
+    <option value="0x">Zero x (0x)</option>
+</select>
                                     <div class="btn-group ms-auto">
-                                        <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>
-                                        <button type="button" class="btn btn-md btn-light btn-copy" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Copy to clipboard" data-bs-original-title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
-                                        <button type="button" class="btn btn-md btn-light btn-download" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Download" data-bs-original-title="Download"><i class="bi bi-download"></i></button>
-                                    </div>
+    <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>
+    <button type="button" class="btn btn-md btn-light btn-copy" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Copy to clipboard" data-bs-original-title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+    <button type="button" class="btn btn-md btn-light btn-download" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Download" data-bs-original-title="Download"><i class="bi bi-download"></i></button>
+</div>
                                 </div>
                             </div>
                         </div>
@@ -356,12 +356,20 @@
                     </div>
                     <div class="card-footer py-3">
                         <div class="d-flex justify-content-start align-items-center">
-                            <button type="button" class="btn btn-md btn-convrtr" id="reverseHexDecode" title="Reverse hex nibbles">Reverse</button>
+                            <button type="button" class="btn btn-md btn-convrtr me-2" id="reverseHexDecode" title="Reverse hex nibbles">Reverse</button>
+                            <select class="form-select w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter">
+    <option value=" " selected="">Space</option>
+    <option value="-">Hyphen</option>
+    <option value=":">Colon</option>
+    <option value=",">Comma</option>
+    <option value="\x">Slash x (\x)</option>
+    <option value="0x">Zero x (0x)</option>
+</select>
                             <div class="btn-group ms-auto">
-                                <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>
-                                <button type="button" class="btn btn-md btn-light btn-copy" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Copy to clipboard" data-bs-original-title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
-                                <button type="button" class="btn btn-md btn-light btn-download" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Download" data-bs-original-title="Download"><i class="bi bi-download"></i></button>
-                            </div>
+    <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>
+    <button type="button" class="btn btn-md btn-light btn-copy" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Copy to clipboard" data-bs-original-title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+    <button type="button" class="btn btn-md btn-light btn-download" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Download" data-bs-original-title="Download"><i class="bi bi-download"></i></button>
+</div>
                         </div>
                         <hr />
                         <div id="reverseHexResults" class="data-to-copy active"></div>

--- a/_site/hex/index.html
+++ b/_site/hex/index.html
@@ -270,7 +270,9 @@
             <hr>
             <p class="px-2">
                 Lazy shift a hexadecimal string up or down: <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">54 65 73 74</code> [test] becomes <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">55 66 74 75</code> [uftu] when shifted 1 to the right (+1) or <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">53 64 72 73</code> [Sdrs] when shifted 1 to the left. 
-                Supports any delimiter is available in the delimiter dropdown, the default is always a space. 
+            </p>
+            <p class="px-2">
+                The dropdown allows you to select a delimiter, which is how your hex values are split up and joined together. The default is a space, you can select no delimiter if your hex contains no spaces.
             </p>
         </div>
         <div class="collapse show" id="shiftHexCollapse">
@@ -298,6 +300,7 @@
     <option value=",">Comma</option>
     <option value="\x">Slash x (\x)</option>
     <option value="0x">Zero x (0x)</option>
+    <option value="">No delimiter</option>
 </select>
                                     <div class="btn-group ms-auto">
     <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>
@@ -346,7 +349,10 @@
             </div>
             <hr>
             <p class="px-2">
-                Unlike reversing the entire string, this reverses each individual hex string. <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">74 65 73 74</code> [test] becomes <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">47 56 37 47</code>.
+                Unlike reversing the entire string, this reverses each individual hex byte. <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">74 65 73 74</code> [test] becomes <code class="d-inline-flex px-2 bg-success bg-opacity-10 border border-success border-opacity-10 rounded-2">47 56 37 47</code>.
+            </p>
+            <p class="px-2">
+                The dropdown allows you to select a delimiter, which is how your hex values are split up and joined together. The default is a space, you can select no delimiter if your hex contains no spaces.
             </p>
         </div>
         <div class="collapse" id="reverseHexCollapse">
@@ -366,6 +372,7 @@
     <option value=",">Comma</option>
     <option value="\x">Slash x (\x)</option>
     <option value="0x">Zero x (0x)</option>
+    <option value="">No delimiter</option>
 </select>
                             <div class="btn-group ms-auto">
     <button type="button" class="btn btn-md btn-light btn-select" data-bs-toggle="tooltip" data-bs-placement="top" aria-label="Select All" data-bs-original-title="Select All"><i class="bi bi-check2-square"></i></button>

--- a/_site/hex/index.html
+++ b/_site/hex/index.html
@@ -406,8 +406,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.5</small>
+            <abbr title="Release version: v1.10.6" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.6</small>
             </abbr>
         </div>
     </div>

--- a/_site/hex/index.html
+++ b/_site/hex/index.html
@@ -253,7 +253,8 @@
         </div>
     </div>
 </section>
-            <section id="shift" class="section">
+            
+<section id="shift" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading mb-4">
             <div class="d-flex justify-content-between section-toggle"
@@ -290,7 +291,7 @@
                                     </div>
                                 </div>
                                 <div class="col d-flex flex-fill justify-content-start mb-2">
-                                    <select class="form-select w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter">
+                                    <select class="form-select w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter" id="shiftHexDelimiter">
     <option value=" " selected="">Space</option>
     <option value="-">Hyphen</option>
     <option value=":">Colon</option>
@@ -329,7 +330,8 @@
         </div>
     </div>
 </section>
-            <section id="reverseHex" class="section">
+            
+<section id="reverseHex" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading mb-4">
             <div class="d-flex justify-content-between section-toggle"
@@ -357,7 +359,7 @@
                     <div class="card-footer py-3">
                         <div class="d-flex justify-content-start align-items-center">
                             <button type="button" class="btn btn-md btn-convrtr me-2" id="reverseHexDecode" title="Reverse hex nibbles">Reverse</button>
-                            <select class="form-select w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter">
+                            <select class="form-select w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter" id="reverseHexDelimiter">
     <option value=" " selected="">Space</option>
     <option value="-">Hyphen</option>
     <option value=":">Colon</option>

--- a/_site/index.html
+++ b/_site/index.html
@@ -253,7 +253,8 @@
         </div>
     </div>
 </section>
-            <section id="convrtrs" class="section">
+            
+<section id="convrtrs" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading">
             <div class="d-flex justify-content-between section-toggle"

--- a/_site/index.html
+++ b/_site/index.html
@@ -253,7 +253,8 @@
         </div>
     </div>
 </section>
-            <section id="convrtrs" class="section">
+            
+<section id="convrtrs" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading">
             <div class="d-flex justify-content-between section-toggle"
@@ -399,14 +400,15 @@
                                     </label>
                                 </span>
                                 
-                                <select id="hexDelimiter" class="form-select form-select-sm mx-2 ms-auto w-auto" aria-label="Change Hexadecimal delimiter">
-                                    <option value=" " selected="">Space</option>
-                                    <option value="-">Hyphen</option>
-                                    <option value=":">Colon</option>
-                                    <option value=",">Comma</option>
-                                    <option value="\x">Slash x (\x)</option>
-                                    <option value="0x">Zero x (0x)</option>
-                                </select>
+                                <select class="form-select form-select-sm mx-2 ms-auto w-auto hex-delimiter" aria-label="Change Hexadecimal delimiter" id="hexDelimiter">
+    <option value=" " selected="">Space</option>
+    <option value="-">Hyphen</option>
+    <option value=":">Colon</option>
+    <option value=",">Comma</option>
+    <option value="\x">Slash x (\x)</option>
+    <option value="0x">Zero x (0x)</option>
+    <option value="">No delimiter</option>
+</select>
                                 
                                 
                                 <div class="d-flex align-items-center">

--- a/_site/index.html
+++ b/_site/index.html
@@ -253,8 +253,7 @@
         </div>
     </div>
 </section>
-            
-<section id="convrtrs" class="section">
+            <section id="convrtrs" class="section">
     <div class="py-4 px-2 px-sm-4">
         <div class="section-heading">
             <div class="d-flex justify-content-between section-toggle"

--- a/_site/index.html
+++ b/_site/index.html
@@ -974,8 +974,8 @@
             </p>
         </div>
         <div class="p-4 pt-2">
-            <abbr title="Release version: v1.10.5" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
-                <small>v1.10.5</small>
+            <abbr title="Release version: v1.10.6" class="d-inline-flex px-2 py-1 fw-semibold bg-success bg-opacity-25 border border-success border-opacity-10 rounded-2 text-decoration-none">
+                <small>v1.10.6</small>
             </abbr>
         </div>
     </div>

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -1,7 +1,7 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    let validHex = /[0-9A-Fa-f]+$/g;
+    const validHex = /[0-9A-Fa-f]+$/g;
     if(validHex.test(string)) {
         return hexToString(string, delimiter).split("").map(c => 
             (ord(c) + parseInt(shiftValue)).toString(16)
@@ -11,12 +11,26 @@ function shiftHexString(string, shiftValue, delimiter) {
     }
 }
 
-// Reverse Hex nibbles
+// Reverse Hex
+// Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
 function reverseHex(string) {
     return stringToHex(hexToString(string), " ").split(" ").map(c => 
             reverseString(c)
            ).join(" ");
 }
+
+// Reverse Hex nibbles
+// Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
+function reverseHexNibbles(string) {
+    const nibbles = [];
+    const strLength = string.length;
+    for (let i = 0; i < strLength; i += 2) {
+        const nibble = parseInt(string.substr(i, 2), 16);
+        nibbles.push(nibble);
+    }
+    return nibbles.reverse().map(nibble => nibble.toString(16)).join("");
+}
+
 
 // Shift Hex
 const shiftButton = document.getElementById("shiftDecode");

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -7,7 +7,7 @@ function shiftHexString(string, shiftValue, delimiter) {
             (ord(c) + parseInt(shiftValue)).toString(16)
         ).join(delimiter);
     } else {
-        throw Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters");
     }
 }
 

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -1,7 +1,7 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
+    
     if(validHex.test(string)) {
         return hexToString(string, delimiter).split("").map(c => 
             (ord(c) + parseInt(shiftValue)).toString(16)
@@ -21,14 +21,12 @@ function reverseHex(string, delimiter) {
 
 // Reverse Hex nibbles
 // Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
-function reverseHexNibbles(string) {
-    const nibbles = [];
-    const strLength = string.length;
-    for (let i = 0; i < strLength; i += 2) {
-        const nibble = parseInt(string.substr(i, 2), 16);
-        nibbles.push(nibble);
+function reverseHexNibbles(string, delimiter) {
+    if(validHex.test(string)) {
+        return string.split(delimiter).reverse().join(delimiter);
+    } else {
+        throw new Error("Hexadecimal contains invalid characters");
     }
-    return nibbles.reverse().map(nibble => nibble.toString(16)).join("");
 }
 
 

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -1,7 +1,8 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    
+    const validHex = /[0-9A-Fa-f]+$/g;
+
     if(validHex.test(string)) {
         return hexToString(string, delimiter).split("").map(c => 
             (ord(c) + parseInt(shiftValue)).toString(16)
@@ -14,14 +15,22 @@ function shiftHexString(string, shiftValue, delimiter) {
 // Reverse Hex
 // Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
 function reverseHex(string, delimiter) {
-    return string.split(delimiter).map(c => 
-              reverseString(c)
-           ).join(delimiter);
+    const validHex = /[0-9A-Fa-f]+$/g;
+
+    if(validHex.test(string)) {
+        return string.split(delimiter).map((c) => 
+            reverseString(c)
+        ).join(delimiter);
+    } else {
+        throw new Error("Hexadecimal contains invalid characters");
+    }
 }
 
 // Reverse Hex nibbles
 // Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
 function reverseHexNibbles(string, delimiter) {
+    const validHex = /[0-9A-Fa-f]+$/g;
+
     if(validHex.test(string)) {
         return string.split(delimiter).reverse().join(delimiter);
     } else {
@@ -29,11 +38,12 @@ function reverseHexNibbles(string, delimiter) {
     }
 }
 
-
 // Shift Hex
 const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
+    let shiftValue = document.getElementById("shiftValue");
+    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -57,19 +67,18 @@ shiftButton.addEventListener("click", function() {
         return;
     }
 
-    let shiftValue = document.getElementById("shiftValue");
-    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
     document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
     document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
     document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
     document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
-    document.getElementById("decimal-tab-pane").textContent =  string2Dec(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("decimal-tab-pane").textContent =  stringToDecimal(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
 });
 
 // Reverse Hex
 const reverseHexButton = document.getElementById("reverseHexDecode");
 reverseHexButton.addEventListener("click", function() {
     const reverseHexString = document.getElementById("reverseHexText");
+    let hexDelimiter = document.getElementById("reverseHexDelimiter").value;
 
     if(!emptyContainerCheck(reverseHexString.value, reverseHexString)) {
         return false;
@@ -78,6 +87,11 @@ reverseHexButton.addEventListener("click", function() {
         return false;
     }
 
-    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
-    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value, hexDelimiter);
+    try {
+        reverseHex(reverseHexString.value.trim(), hexDelimiter);
+    } catch (e) {
+        showToast("Error", `An error occured trying to reverse the hex string: ${e.message}`, "danger");
+        return;
+    }
+    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value.trim(), hexDelimiter);
 });

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -13,10 +13,10 @@ function shiftHexString(string, shiftValue, delimiter) {
 
 // Reverse Hex
 // Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
-function reverseHex(string) {
-    return stringToHex(hexToString(string), " ").split(" ").map(c => 
-            reverseString(c)
-           ).join(" ");
+function reverseHex(string, delimiter) {
+    return string.split(delimiter).map(c => 
+              reverseString(c)
+           ).join(delimiter);
 }
 
 // Reverse Hex nibbles
@@ -36,8 +36,6 @@ function reverseHexNibbles(string) {
 const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
-    let shiftValue = document.getElementById("shiftValue");
-    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -61,6 +59,8 @@ shiftButton.addEventListener("click", function() {
         return;
     }
 
+    let shiftValue = document.getElementById("shiftValue");
+    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
     document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
     document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
     document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
@@ -80,5 +80,6 @@ reverseHexButton.addEventListener("click", function() {
         return false;
     }
 
-    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value);
+    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
+    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value, hexDelimiter);
 });

--- a/assets/js/hex/hex.js
+++ b/assets/js/hex/hex.js
@@ -1,40 +1,36 @@
 // Shift Hex left or right
 // Returns: Decimal, space delimited
 function shiftHexString(string, shiftValue, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if(validHex.test(string)) {
-        return hexToString(string, delimiter).split("").map(c => 
-            (ord(c) + parseInt(shiftValue)).toString(16)
-        ).join(delimiter);
+    if(isValidHex(string, delimiter)) {
+        return hexToString(string, delimiter).split("").map(c => (ord(c) + parseInt(shiftValue)).toString(16)).join(delimiter);
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 
 // Reverse Hex
 // Swaps the order of each hex nibble: 74 65 73 74 [test] becomes 47 56 37 47
 function reverseHex(string, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if(validHex.test(string)) {
-        return string.split(delimiter).map((c) => 
-            reverseString(c)
-        ).join(delimiter);
+    let reversedString;
+    if(isValidHex(string, delimiter)) {
+        if(delimiter === "") {
+            reversedString = stringToArray(string, 2).map((c) => reverseString(c)).join(delimiter);
+        } else {
+            reversedString = string.split(delimiter).map((c) => reverseString(c)).join(delimiter);
+        }
+        return reversedString;
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 
 // Reverse Hex nibbles
 // Reverses the position of each Hex nibble: 74 65 73 74 becomes 74 73 65 74
 function reverseHexNibbles(string, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if(validHex.test(string)) {
+    if(isValidHex(string, delimiter)) {
         return string.split(delimiter).reverse().join(delimiter);
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 
@@ -43,7 +39,7 @@ const shiftButton = document.getElementById("shiftDecode");
 shiftButton.addEventListener("click", function() {
     const shiftString = document.getElementById("shiftText");
     let shiftValue = document.getElementById("shiftValue");
-    let hexDelimiter = document.getElementById("shiftHexDelimiter").value;
+    let shiftHexDelimiter = document.getElementById("shiftHexDelimiter").value;
 
     if(!emptyContainerCheck(shiftString.value, shiftString)) {
         document.getElementById("text-tab-pane").textContent = "";
@@ -61,24 +57,24 @@ shiftButton.addEventListener("click", function() {
     }
 
     try {
-        shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
+        shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter);
     } catch (e) {
         showToast("Error", `An error occured trying to shift the hex string: ${e.message}`, "danger");
         return;
     }
 
-    document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter);
-    document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
-    document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter);
-    document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
-    document.getElementById("decimal-tab-pane").textContent =  stringToDecimal(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, hexDelimiter), hexDelimiter));
+    document.getElementById("text-tab-pane").textContent = hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter);
+    document.getElementById("binary-tab-pane").textContent = stringToBinary(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter));
+    document.getElementById("hex-tab-pane").textContent = shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter);
+    document.getElementById("base64-tab-pane").textContent = stringToBase64(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter));
+    document.getElementById("decimal-tab-pane").textContent =  stringToDecimal(hexToString(shiftHexString(shiftString.value.trim(), shiftValue.value, shiftHexDelimiter), shiftHexDelimiter));
 });
 
 // Reverse Hex
 const reverseHexButton = document.getElementById("reverseHexDecode");
 reverseHexButton.addEventListener("click", function() {
     const reverseHexString = document.getElementById("reverseHexText");
-    let hexDelimiter = document.getElementById("reverseHexDelimiter").value;
+    let reverseHexDelimiter = document.getElementById("reverseHexDelimiter").value;
 
     if(!emptyContainerCheck(reverseHexString.value, reverseHexString)) {
         return false;
@@ -88,10 +84,10 @@ reverseHexButton.addEventListener("click", function() {
     }
 
     try {
-        reverseHex(reverseHexString.value.trim(), hexDelimiter);
+        reverseHex(reverseHexString.value.trim(), reverseHexDelimiter);
     } catch (e) {
         showToast("Error", `An error occured trying to reverse the hex string: ${e.message}`, "danger");
         return;
     }
-    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value.trim(), hexDelimiter);
+    document.getElementById("reverseHexResults").textContent = reverseHex(reverseHexString.value.trim(), reverseHexDelimiter);
 });

--- a/assets/js/home/convrtrs.js
+++ b/assets/js/home/convrtrs.js
@@ -1,4 +1,6 @@
 // Make it so
+let hexDelimiter = document.getElementById("hexDelimiter").value;
+
 document.getElementById("encode").addEventListener("click", function() {
     const container = this.closest(".card-body").querySelector("textarea");
     const data = container.value;
@@ -11,7 +13,7 @@ document.getElementById("encode").addEventListener("click", function() {
     }
 
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(data);
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(data);
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(data, hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(data);
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(data);
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
@@ -41,7 +43,7 @@ document.getElementById("binaryDecode").addEventListener("click", function() {
         return;
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = binaryToString(data);
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(binaryToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(binaryToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(binaryToString(data));
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(binaryToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
@@ -65,19 +67,19 @@ document.getElementById("hexDecode").addEventListener("click", function() {
     }
 
     try {
-        hexToString(data);
+        hexToString(data, hexDelimiter);
     } catch (e) {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
-    document.getElementById("convrtr-text").querySelector("textarea").value = hexToString(data);
-    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data));
-    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data));
-    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data));
+    document.getElementById("convrtr-text").querySelector("textarea").value = hexToString(data, hexDelimiter);
+    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data), hexDelimiter);
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(data);
-    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data));
-    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data));
+    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data), hexDelimiter);
 });
 
 
@@ -102,7 +104,7 @@ document.getElementById("b64Decode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = base64ToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(base64ToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(base64ToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(base64ToString(data), hexDelimiter);
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(base64ToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = "";
@@ -132,7 +134,7 @@ document.getElementById("decDecode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = decimalToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(decimalToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(decimalToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(decimalToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(decimalToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(data);
@@ -160,9 +162,12 @@ document.getElementById("revDecode").addEventListener("click", function() {
         showToast("Error", "An error occured trying to decode the data.", "danger");
         return;
     }
+
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
+    console.log("Delimiter", hexDelimiter);
     document.getElementById("convrtr-text").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = reverseString(stringToBinary(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = reverseString(stringToBase64(data));
     document.getElementById("convrtr-decimal").querySelector("textarea").value = reverseString(stringToDecimal(data));
     document.getElementById("convrtr-rot13").querySelector("textarea").value = reverseString(rot13(data));
@@ -192,7 +197,7 @@ document.getElementById("rot13Decode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = rot13(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(rot13(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(rot13(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(rot13(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(rot13(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(rot13(data));
@@ -222,7 +227,7 @@ document.getElementById("morseDecode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = morseToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morseToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morseToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morseToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(morseToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(morseToString(data));
@@ -252,7 +257,7 @@ document.getElementById("mrsnryDecode").addEventListener("click", function() {
     }
     document.getElementById("convrtr-text").querySelector("textarea").value = morsenaryToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morsenaryToString(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morsenaryToString(data));
+    document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morsenaryToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(morsenaryToString(data));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = "";

--- a/assets/js/home/convrtrs.js
+++ b/assets/js/home/convrtrs.js
@@ -1,9 +1,8 @@
 // Make it so
-let hexDelimiter = document.getElementById("hexDelimiter").value;
-
 document.getElementById("encode").addEventListener("click", function() {
     const container = this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -28,6 +27,7 @@ document.getElementById("binaryDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -42,6 +42,7 @@ document.getElementById("binaryDecode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = binaryToString(data);
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(binaryToString(data), hexDelimiter);
     document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(binaryToString(data));
@@ -58,6 +59,7 @@ document.getElementById("hexDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -72,14 +74,15 @@ document.getElementById("hexDecode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = hexToString(data, hexDelimiter);
-    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data), hexDelimiter);
-    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data), hexDelimiter);
-    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(hexToString(data, hexDelimiter));
+    document.getElementById("convrtr-base64").querySelector("textarea").value = stringToBase64(hexToString(data, hexDelimiter));
+    document.getElementById("convrtr-decimal").querySelector("textarea").value = stringToDecimal(hexToString(data, hexDelimiter));
     document.getElementById("convrtr-reverse").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-rot13").querySelector("textarea").value = rot13(data);
-    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data), hexDelimiter);
-    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data), hexDelimiter);
+    document.getElementById("convrtr-morse").querySelector("textarea").value = stringToMorse(hexToString(data, hexDelimiter));
+    document.getElementById("convrtr-morsenary").querySelector("textarea").value = stringToMorsenary(hexToString(data, hexDelimiter));
 });
 
 
@@ -88,6 +91,7 @@ document.getElementById("b64Decode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -102,6 +106,7 @@ document.getElementById("b64Decode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = base64ToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(base64ToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(base64ToString(data), hexDelimiter);
@@ -118,6 +123,7 @@ document.getElementById("decDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -132,6 +138,7 @@ document.getElementById("decDecode").addEventListener("click", function() {
         showToast("Error", "An error occured trying to decode the data.", "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = decimalToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(decimalToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(decimalToString(data), hexDelimiter);
@@ -148,6 +155,7 @@ document.getElementById("revDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -163,11 +171,9 @@ document.getElementById("revDecode").addEventListener("click", function() {
         return;
     }
 
-    let hexDelimiter = document.getElementById("hexDelimiter").value;
-    console.log("Delimiter", hexDelimiter);
     document.getElementById("convrtr-text").querySelector("textarea").value = reverseString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = reverseString(stringToBinary(data));
-    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data), hexDelimiter);
+    document.getElementById("convrtr-hex").querySelector("textarea").value = reverseString(stringToHex(data, hexDelimiter));
     document.getElementById("convrtr-base64").querySelector("textarea").value = reverseString(stringToBase64(data));
     document.getElementById("convrtr-decimal").querySelector("textarea").value = reverseString(stringToDecimal(data));
     document.getElementById("convrtr-rot13").querySelector("textarea").value = reverseString(rot13(data));
@@ -181,6 +187,7 @@ document.getElementById("rot13Decode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -195,6 +202,7 @@ document.getElementById("rot13Decode").addEventListener("click", function() {
         showToast("Error", "An error occured trying to decode the data.", "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = rot13(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(rot13(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(rot13(data), hexDelimiter);
@@ -211,6 +219,7 @@ document.getElementById("morseDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -225,6 +234,7 @@ document.getElementById("morseDecode").addEventListener("click", function() {
         showToast("Error", `An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = morseToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morseToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morseToString(data), hexDelimiter);
@@ -241,6 +251,7 @@ document.getElementById("mrsnryDecode").addEventListener("click", function() {
     const chainDecoders = document.getElementById("chainDecoders");
     const container = chainDecoders.checked ? document.getElementById("form-text") : this.closest(".card-body").querySelector("textarea");
     const data = container.value;
+    let hexDelimiter = document.getElementById("hexDelimiter").value;
 
     if(!emptyContainerCheck(data, container)) {
         return false;
@@ -255,6 +266,7 @@ document.getElementById("mrsnryDecode").addEventListener("click", function() {
         showToast("Error",`An error occured trying to decode the data: ${e.message}`, "danger");
         return;
     }
+
     document.getElementById("convrtr-text").querySelector("textarea").value = morsenaryToString(data);
     document.getElementById("convrtr-binary").querySelector("textarea").value = stringToBinary(morsenaryToString(data));
     document.getElementById("convrtr-hex").querySelector("textarea").value = stringToHex(morsenaryToString(data), hexDelimiter);

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -29,6 +29,15 @@ function base64ToString(string) {
     } catch (e) {
         throw Error("Not a valid Base64 string");
     }
+
+    // try {
+    //     const decodedString = atob(base64String);
+    //     const utf8String = decodeURIComponent(encodeURIComponent(decodedString));
+    //     return utf8String;
+    // } catch (error) {
+    //     console.error("Error decoding Base64 string:", error);
+    //     return null;
+    // }
 }
 
 // Morse code to String

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -1,17 +1,23 @@
 // Decode Binary
+function isValidBinaryLength(string) {
+    return string.length % 8 === 0;
+}
+
 function binaryToString(string) {
-    let stringReplacement = string.replace(/[\D2-9]/g,""); // Strip everything but 1s and 0s
-    string = string.replace(/[^w\s10]/g); // Same, but preserve spaces
-    // Probably better ways to handle this, but make sure the string is divible by 8
-    // If it's not, it's probably an incomplete binary string
-    if((stringReplacement.length > 0 && stringReplacement.length % 8) === 0) {
-        return String.fromCharCode(
-            ...string.split(" ").map(bin => parseInt(bin, 2))
-        );
+    if(isValidBinaryLength(string)) {
+        string = string.replace(/[^10\s]/g, "");
+
+        let charCodes = string.split(" ").map(bin => {
+            bin = bin.padStart(8, "0");
+            return parseInt(bin, 2);
+        });
+
+        return String.fromCharCode(...charCodes);
     } else {
         throw Error("Not a valid Binary string");
     }
 }
+
 
 // Decode Base64
 function base64ToString(string) {

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -60,15 +60,16 @@ function stringToMorse(string) {
 // Convert to Morsenary
 function stringToMorsenary(string) {
     let morsenarySetting = document.getElementById("morsenarySetting").value;
-    return morsenarySetting === "default" ? stringToBinary(string).replace(/ /g,"").replaceAll("0",".").replaceAll("1","-") :
-                                        stringToBinary(string).replace(/ /g,"").replaceAll("1",".").replaceAll("0","-");
+    return morsenarySetting === "default" ? stringToBinary(string).replace(/ /g, '').replace(/[01]/g, (match) => (match === '1' ? '-' : '.')) :
+    stringToBinary(string).replace(/ /g, '').replace(/[01]/g, (match) => (match === '1' ? '.' : '-'));
 }
+
 
 // Decode Morsenary to String
 function morsenaryToString(string) {
     if(/^[ /.-]*$/.test(string)) {
         let morsenarySetting = document.getElementById("morsenarySetting").value;
-        string = morsenarySetting === "default" ? string.replaceAll(".","0").replaceAll("-","1") : string.replaceAll(".","1").replaceAll("-","0");
+        string = morsenarySetting === "default" ? string.replace(/[.-]/g, (match) => (match === '.' ? '0' : '1')) : string.replace(/[.-]/g, (match) => (match === '.' ? '1' : '0'));
         return binaryToString(splitString(string, 8));
     } else {
        throw Error("Morsenary contains invalid characters");

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -162,7 +162,6 @@ function styledArrayFrequencies(data) {
 let hexDelimiterSelect = document.getElementById("hexDelimiter");
 hexDelimiterSelect.addEventListener("change", function() {
     let hexData = document.getElementById("form-hex").value;
-    console.log(hexData);
     if(hexData === "") {
         return;
     }

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -14,7 +14,7 @@ function binaryToString(string) {
 
         return String.fromCharCode(...charCodes);
     } else {
-        throw Error("Not a valid Binary string");
+        throw new Error("Not a valid Binary string");
     }
 }
 
@@ -54,7 +54,7 @@ function morseToString(string) {
             .join(" ")
             .trim();
     } else {
-        throw Error("Morse code contains invalid characters");
+        throw new Error("Morse code contains invalid characters");
     }
 }
 
@@ -87,7 +87,7 @@ function morsenaryToString(string) {
         string = morsenarySetting === "default" ? string.replace(/[.-]/g, (match) => (match === '.' ? '0' : '1')) : string.replace(/[.-]/g, (match) => (match === '.' ? '1' : '0'));
         return binaryToString(splitString(string, 8));
     } else {
-       throw Error("Morsenary contains invalid characters");
+       throw new Error("Morsenary contains invalid characters");
     }
 }
 

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -22,22 +22,14 @@ function binaryToString(string) {
 // Decode Base64
 function base64ToString(string) {
     // Going backwards: from bytestream, to percent-encoding, to original string.
+    // https://stackoverflow.com/a/30106551/3172872
     try {
         return decodeURIComponent(atob(string).split("").map(function(c) {
             return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
         }).join(""));
     } catch (e) {
-        throw Error("Not a valid Base64 string");
+        throw new Error("Not a valid Base64 string");
     }
-
-    // try {
-    //     const decodedString = atob(base64String);
-    //     const utf8String = decodeURIComponent(encodeURIComponent(decodedString));
-    //     return utf8String;
-    // } catch (error) {
-    //     console.error("Error decoding Base64 string:", error);
-    //     return null;
-    // }
 }
 
 // Morse code to String

--- a/assets/js/home/home.js
+++ b/assets/js/home/home.js
@@ -158,17 +158,18 @@ function styledArrayFrequencies(data) {
     return result;
 }
 
-// Re-code Hex on delimeter change
+// Re-code Hex on delimiter change
 let hexDelimiterSelect = document.getElementById("hexDelimiter");
 hexDelimiterSelect.addEventListener("change", function() {
     let hexData = document.getElementById("form-hex").value;
+    console.log(hexData);
     if(hexData === "") {
         return;
     }
     document.getElementById("encode").click();
 });
 
-// Re-code Morsenary on delimeter change
+// Re-code Morsenary on delimiter change
 let morsenarySelect = document.getElementById("morsenarySetting");
 morsenarySelect.addEventListener("change", function() {
     let morsenaryData = document.getElementById("form-morsenary").value;

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -1,6 +1,7 @@
 const alphabet	= " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 const alphaFlip	= " ⱯQƆPƎℲפHIſʞ˥WNOԀQɹS┴∩ΛMX⅄Zɐqɔpǝɟƃɥıɾʞןɯuodbɹsʇnʌʍxʎz";
 const alphaRot  = " NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm";
+const validHex = /[0-9A-Fa-f]+$/g;
 
 // Morse map
 const morseTextDict = {  
@@ -70,8 +71,6 @@ function stringToHex(string, delimiter) { // UTF-8
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
 function hexToString(string, delimiter) {
-    let validHex = /[0-9A-Fa-f]+$/g;
-
     if (validHex.test(string)) {
         const hex = Array.from(string.trim().split(delimiter));
         const len = hex.length;

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -55,10 +55,15 @@ function stringToBinary(string) {
     return Array.from(string).map(c => c.charCodeAt().toString(2).padStart(8,0)).join(" ");
 }
 
+function isValidHex(string, delimiter) {
+    const validHex = /^[0-9A-Fa-f]+$/g;
+    let hexTest = string.replaceAll(delimiter, "");
+    return validHex.test(hexTest);
+}
+
 // Convert to Hex
 // https://stackoverflow.com/a/69420340/3172872
 function stringToHex(string, delimiter) { // UTF-8
-    console.log(delimiter);
     let returnValue = Array.from(string).map(c => 
         c.charCodeAt(0) < 128 ? c.charCodeAt(0).toString(16).padStart(2, '0') : 
         encodeURIComponent(c).replace(/\%/g,"").toLowerCase()
@@ -70,19 +75,24 @@ function stringToHex(string, delimiter) { // UTF-8
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
 function hexToString(string, delimiter) {
-    const validHex = /[0-9A-Fa-f]+$/g;
-
-    if (validHex.test(string)) {
-        const hex = Array.from(string.trim().split(delimiter));
-        const len = hex.length;
+    if (isValidHex(string, delimiter)) {
         let hexArray = [];
-
-        for (let i = 0; i < len; i++) {
-            hexArray.push(String.fromCharCode(parseInt(hex[i], 16)));
+        const len = string.length;
+        if(delimiter === "") {
+            for (let i = 0; i < len; i += 2) {
+                const chunk = string.slice(i, i + 2);
+                hexArray.push(String.fromCharCode(parseInt(chunk, 16)));
+            }
+        } else {
+            const hex = Array.from(string.trim().split(delimiter));
+            const len = hex.length;
+            for (let i = 0; i < len; i++) {
+                hexArray.push(String.fromCharCode(parseInt(hex[i], 16)));
+            }
         }
         return hexArray.join("");
     } else {
-        throw new Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters, check you have selected the correct delimiter");
     }
 }
 

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -1,7 +1,6 @@
 const alphabet	= " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 const alphaFlip	= " ⱯQƆPƎℲפHIſʞ˥WNOԀQɹS┴∩ΛMX⅄Zɐqɔpǝɟƃɥıɾʞןɯuodbɹsʇnʌʍxʎz";
 const alphaRot  = " NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm";
-const validHex = /[0-9A-Fa-f]+$/g;
 
 // Morse map
 const morseTextDict = {  
@@ -71,6 +70,8 @@ function stringToHex(string, delimiter) { // UTF-8
 // Decode Hex to string
 // https://stackoverflow.com/a/60505243/3172872
 function hexToString(string, delimiter) {
+    const validHex = /[0-9A-Fa-f]+$/g;
+
     if (validHex.test(string)) {
         const hex = Array.from(string.trim().split(delimiter));
         const len = hex.length;

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -58,13 +58,13 @@ function stringToBinary(string) {
 // Convert to Hex
 // https://stackoverflow.com/a/69420340/3172872
 function stringToHex(string, delimiter) { // UTF-8
-    let hexDelimiter = delimiter ? delimiter : document.getElementById("hexDelimiter").value;
+    console.log(delimiter);
     let returnValue = Array.from(string).map(c => 
         c.charCodeAt(0) < 128 ? c.charCodeAt(0).toString(16).padStart(2, '0') : 
         encodeURIComponent(c).replace(/\%/g,"").toLowerCase()
-    ).join(`${hexDelimiter}`);
+    ).join(`${delimiter}`);
 
-    return (hexDelimiter === "\\x" || hexDelimiter === "0x") ? hexDelimiter + returnValue : returnValue;
+    return (delimiter === "\\x" || delimiter === "0x") ? delimiter + returnValue : returnValue;
 }
 
 // Decode Hex to string
@@ -73,8 +73,7 @@ function hexToString(string, delimiter) {
     let validHex = /[0-9A-Fa-f]+$/g;
 
     if (validHex.test(string)) {
-        let hexDelimiter = delimiter ? delimiter : document.getElementById("hexDelimiter").value;
-        const hex = Array.from(string.trim().split(hexDelimiter));
+        const hex = Array.from(string.trim().split(delimiter));
         const len = hex.length;
         let hexArray = [];
 

--- a/assets/js/toolkit.js
+++ b/assets/js/toolkit.js
@@ -83,7 +83,7 @@ function hexToString(string, delimiter) {
         }
         return hexArray.join("");
     } else {
-        throw Error("Hexadecimal contains invalid characters");
+        throw new Error("Hexadecimal contains invalid characters");
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convrtrjs",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "A simple JavaScript based tool to quickly convert text between different formats",
   "tagline": "For everlost and Grollow!",
   "main": "index.html",


### PR DESCRIPTION
## New features
- Added ability to reverse hex nibbles, different from functionality that was there already, and wording updated to reflect. This functionality is not yet exposed in the UI, will be in a future update.
- Added validation function for hex string
- Added validation function for binary string
- Added ability to use "No delimiter" in a hex conversion, so you can drop in a string with just hex characters and correctly convert to and from

## Changes
- Improved performance of morsernary by moving to a single match, rather than chaining
- Improved and simplified the reveseHex function
- Improved error handling across functions
- Moved delimiter dropdown to a liquid partial, so that it can be reused across the site

## Bug fixes
- Correctly pass values from the delimiter dropdown through to all the functions that require it