### PR TITLE
V 2.0.3

### DIFF
--- a/_data/labels.json
+++ b/_data/labels.json
@@ -1,51 +1,9 @@
 {
     "labels": [
         {
-            "key": "improvements",
-            "friendlyName": "Improvements",
-            "description": "General improvements",
-            "visible": true
-        },
-        {
-            "key": "a11y",
-            "friendlyName": "Accessibility",
-            "description": "Accessibility improvements",
-            "visible": true
-        },
-        {
-            "key": "bug-fixes",
-            "friendlyName": "Bug Fixes",
-            "description": "Fixed something that wasn't working",
-            "visible": true
-        },
-        {
-            "key": "bug",
-            "friendlyName": "Bug",
-            "description": "Something isn't working",
-            "visible": false
-        },
-        {
-            "key": "documentation",
-            "friendlyName": "Documentation",
-            "description": "Improvements or additions to documentation",
-            "visible": true
-        },
-        {
-            "key": "duplicate",
-            "friendlyName": "Duplicate",
-            "description": "This issue or pull request already exists",
-            "visible": false
-        },
-        {
-            "key": "feature-request",
-            "friendlyName": "Feature request",
-            "description": "New feature or request",
-            "visible": true
-        },
-        {
-            "key": "hotfix",
-            "friendlyName": "Hotfix",
-            "description": "Quick fix to resolve a bug or minor issue",
+            "key": "release",
+            "friendlyName": "Release",
+            "description": "Officially tagged and released version",
             "visible": true
         },
         {
@@ -61,27 +19,33 @@
             "visible": true
         },
         {
-            "key": "new-features",
-            "friendlyName": "New Features",
-            "description": "Introduction of new features",
-            "visible": true
-        },
-        {
             "key": "patch",
             "friendlyName": "Patch",
             "description": "Bug fixes and patches",
             "visible": true
         },
         {
-            "key": "question",
-            "friendlyName": "Question",
-            "description": "A query about the repo, tools, code, etc",
-            "visible": false
+            "key": "hotfix",
+            "friendlyName": "Hotfix",
+            "description": "Quick fix to resolve a bug or minor issue",
+            "visible": true
         },
         {
-            "key": "release",
-            "friendlyName": "Release",
-            "description": "Officially tagged and released version",
+            "key": "new-features",
+            "friendlyName": "New Features",
+            "description": "Introduction of new features",
+            "visible": true
+        },
+        {
+            "key": "improvements",
+            "friendlyName": "Improvements",
+            "description": "General improvements",
+            "visible": true
+        },
+        {
+            "key": "bug-fixes",
+            "friendlyName": "Bug Fixes",
+            "description": "Fixed something that wasn't working",
             "visible": true
         },
         {
@@ -89,6 +53,42 @@
             "friendlyName": "Security",
             "description": "Security/vulnerability/CVE related updates",
             "visible": true
+        },
+        {
+            "key": "a11y",
+            "friendlyName": "Accessibility",
+            "description": "Accessibility improvements",
+            "visible": true
+        },
+        {
+            "key": "documentation",
+            "friendlyName": "Documentation",
+            "description": "Improvements or additions to documentation",
+            "visible": true
+        },
+        {
+            "key": "feature-request",
+            "friendlyName": "Feature request",
+            "description": "New feature or request",
+            "visible": true
+        },
+        {
+            "key": "bug",
+            "friendlyName": "Bug",
+            "description": "Something isn't working",
+            "visible": false
+        },
+        {
+            "key": "duplicate",
+            "friendlyName": "Duplicate",
+            "description": "This issue or pull request already exists",
+            "visible": false
+        },
+        {
+            "key": "question",
+            "friendlyName": "Question",
+            "description": "A query about the repo, tools, code, etc",
+            "visible": false
         },
         {
             "key": "wontfix",

--- a/_data/labels.json
+++ b/_data/labels.json
@@ -3,82 +3,98 @@
         {
             "key": "improvements",
             "friendlyName": "Improvements",
-            "description": "General improvements"
+            "description": "General improvements",
+            "visible": true
         },
         {
             "key": "a11y",
             "friendlyName": "Accessibility",
-            "description": "Accessibility improvements"
+            "description": "Accessibility improvements",
+            "visible": true
         },
         {
             "key": "bug-fixes",
             "friendlyName": "Bug Fixes",
-            "description": "Fixed something that wasn't working"
+            "description": "Fixed something that wasn't working",
+            "visible": true
         },
         {
             "key": "bug",
             "friendlyName": "Bug",
-            "description": "Something isn't working"
+            "description": "Something isn't working",
+            "visible": false
         },
         {
             "key": "documentation",
             "friendlyName": "Documentation",
-            "description": "Improvements or additions to documentation"
+            "description": "Improvements or additions to documentation",
+            "visible": true
         },
         {
             "key": "duplicate",
             "friendlyName": "Duplicate",
-            "description": "This issue or pull request already exists"
+            "description": "This issue or pull request already exists",
+            "visible": false
         },
         {
             "key": "feature-request",
             "friendlyName": "Feature request",
-            "description": "New feature or request"
+            "description": "New feature or request",
+            "visible": true
         },
         {
             "key": "hotfix",
             "friendlyName": "Hotfix",
-            "description": "Quick fix to resolve a bug or minor issue"
+            "description": "Quick fix to resolve a bug or minor issue",
+            "visible": true
         },
         {
             "key": "major",
             "friendlyName": "Major Update",
-            "description": "Major feature updates"
+            "description": "Major feature updates",
+            "visible": true
         },
         {
             "key": "minor",
             "friendlyName": "Minor Update",
-            "description": "Minor feature updates"
+            "description": "Minor feature updates",
+            "visible": true
         },
         {
             "key": "new-features",
             "friendlyName": "New Features",
-            "description": "Introduction of new features"
+            "description": "Introduction of new features",
+            "visible": true
         },
         {
             "key": "patch",
             "friendlyName": "Patch",
-            "description": "Bug fixes and patches"
+            "description": "Bug fixes and patches",
+            "visible": true
         },
         {
             "key": "question",
             "friendlyName": "Question",
-            "description": "A query about the repo, tools, code, etc"
+            "description": "A query about the repo, tools, code, etc",
+            "visible": false
         },
         {
             "key": "release",
             "friendlyName": "Release",
-            "description": "Officially tagged and released version"
+            "description": "Officially tagged and released version",
+            "visible": true
         },
         {
             "key": "security",
             "friendlyName": "Security",
-            "description": "Security/vulnerability/CVE related updates"
+            "description": "Security/vulnerability/CVE related updates",
+            "visible": true
         },
         {
             "key": "wontfix",
             "friendlyName": "Won't fix",
-            "description": "This will not be worked on or fixed"
+            "description": "This will not be worked on or fixed",
+            "visible": false
         }
     ]
 }

--- a/_site/404.html
+++ b/_site/404.html
@@ -396,9 +396,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.0.1/index.html
+++ b/_site/changelog/1.0.1/index.html
@@ -448,9 +448,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.1.0/index.html
+++ b/_site/changelog/1.1.0/index.html
@@ -452,9 +452,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.1.1/index.html
+++ b/_site/changelog/1.1.1/index.html
@@ -451,9 +451,9 @@ Fixes <a href="https://github.com/stickerboy/convrtrjs/issues/4">Add github and 
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.0/index.html
+++ b/_site/changelog/1.10.0/index.html
@@ -461,9 +461,9 @@ A table of common files and the first few bytes of their header in hexadecimal f
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.1/index.html
+++ b/_site/changelog/1.10.1/index.html
@@ -456,9 +456,9 @@ https://github.com/twbs/bootstrap/commit/73e1dcf43eff8371dde52ce41bd1d9fdc2b47d1
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.3/index.html
+++ b/_site/changelog/1.10.3/index.html
@@ -454,9 +454,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.4/index.html
+++ b/_site/changelog/1.10.4/index.html
@@ -450,9 +450,9 @@ Resulted in incorrect results for things like carriage returns</li>
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.5/index.html
+++ b/_site/changelog/1.10.5/index.html
@@ -456,9 +456,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.6/index.html
+++ b/_site/changelog/1.10.6/index.html
@@ -464,9 +464,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.7/index.html
+++ b/_site/changelog/1.10.7/index.html
@@ -454,9 +454,9 @@ An updated description of what each reversal does has been added to the componen
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.10.8/index.html
+++ b/_site/changelog/1.10.8/index.html
@@ -451,9 +451,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.11.0/index.html
+++ b/_site/changelog/1.11.0/index.html
@@ -451,9 +451,9 @@ Under a new Misc section is the Elements, the ability to perform conversions bet
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.12.0/index.html
+++ b/_site/changelog/1.12.0/index.html
@@ -451,9 +451,9 @@ As the header was getting a little cluttered with all the new sections, it has n
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.12.1/index.html
+++ b/_site/changelog/1.12.1/index.html
@@ -453,9 +453,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.12.2/index.html
+++ b/_site/changelog/1.12.2/index.html
@@ -448,9 +448,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.12.3/index.html
+++ b/_site/changelog/1.12.3/index.html
@@ -457,9 +457,9 @@ Where previously all results were displayed in lowercase, regardless of case ent
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.12.4/index.html
+++ b/_site/changelog/1.12.4/index.html
@@ -451,9 +451,9 @@ Additionally, regrouped and renamed some commands</li>
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.13.0/index.html
+++ b/_site/changelog/1.13.0/index.html
@@ -450,9 +450,9 @@ Added a glyph conversion for Halo Forerunner symbols, under Miscellaneous. Click
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.14.0/index.html
+++ b/_site/changelog/1.14.0/index.html
@@ -450,9 +450,9 @@ Added a glyph conversion for Halo Covenant symbols, under Miscellaneous. Click t
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.14.1/index.html
+++ b/_site/changelog/1.14.1/index.html
@@ -448,9 +448,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.15.0/index.html
+++ b/_site/changelog/1.15.0/index.html
@@ -454,9 +454,9 @@ Added support for converting from Braille to text and from text to Braille, unde
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.15.1/index.html
+++ b/_site/changelog/1.15.1/index.html
@@ -465,9 +465,9 @@ Primary color for Convrtr has now changed to a slightly darker share of green</l
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.16.0/index.html
+++ b/_site/changelog/1.16.0/index.html
@@ -462,9 +462,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.0/index.html
+++ b/_site/changelog/1.17.0/index.html
@@ -495,9 +495,9 @@ Shifts the bytes of the input string based on the provided key.</li>
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.1/index.html
+++ b/_site/changelog/1.17.1/index.html
@@ -449,9 +449,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.10/index.html
+++ b/_site/changelog/1.17.10/index.html
@@ -453,9 +453,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.11/index.html
+++ b/_site/changelog/1.17.11/index.html
@@ -454,9 +454,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.2/index.html
+++ b/_site/changelog/1.17.2/index.html
@@ -458,9 +458,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.3/index.html
+++ b/_site/changelog/1.17.3/index.html
@@ -454,9 +454,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.4/index.html
+++ b/_site/changelog/1.17.4/index.html
@@ -463,9 +463,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.5/index.html
+++ b/_site/changelog/1.17.5/index.html
@@ -462,9 +462,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.6/index.html
+++ b/_site/changelog/1.17.6/index.html
@@ -442,9 +442,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.7/index.html
+++ b/_site/changelog/1.17.7/index.html
@@ -438,9 +438,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.8/index.html
+++ b/_site/changelog/1.17.8/index.html
@@ -462,9 +462,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.17.9/index.html
+++ b/_site/changelog/1.17.9/index.html
@@ -454,9 +454,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.18.0/index.html
+++ b/_site/changelog/1.18.0/index.html
@@ -454,9 +454,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.19.0/index.html
+++ b/_site/changelog/1.19.0/index.html
@@ -450,9 +450,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.2.0/index.html
+++ b/_site/changelog/1.2.0/index.html
@@ -442,9 +442,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.2.1/index.html
+++ b/_site/changelog/1.2.1/index.html
@@ -442,9 +442,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.2.2/index.html
+++ b/_site/changelog/1.2.2/index.html
@@ -443,9 +443,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.2.3/index.html
+++ b/_site/changelog/1.2.3/index.html
@@ -437,9 +437,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.20.0/index.html
+++ b/_site/changelog/1.20.0/index.html
@@ -450,9 +450,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.3.0/index.html
+++ b/_site/changelog/1.3.0/index.html
@@ -443,9 +443,9 @@ Remove bg-light class in favor of a new section class, which auto-alternates the
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.4.0/index.html
+++ b/_site/changelog/1.4.0/index.html
@@ -448,9 +448,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.5.0/index.html
+++ b/_site/changelog/1.5.0/index.html
@@ -463,9 +463,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.5.1/index.html
+++ b/_site/changelog/1.5.1/index.html
@@ -450,9 +450,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.5.2/index.html
+++ b/_site/changelog/1.5.2/index.html
@@ -459,9 +459,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.5.3/index.html
+++ b/_site/changelog/1.5.3/index.html
@@ -443,9 +443,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.5.4/index.html
+++ b/_site/changelog/1.5.4/index.html
@@ -448,9 +448,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.6.0/index.html
+++ b/_site/changelog/1.6.0/index.html
@@ -453,9 +453,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.7.0/index.html
+++ b/_site/changelog/1.7.0/index.html
@@ -455,9 +455,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.7.1/index.html
+++ b/_site/changelog/1.7.1/index.html
@@ -449,9 +449,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.7.2/index.html
+++ b/_site/changelog/1.7.2/index.html
@@ -449,9 +449,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.8.0/index.html
+++ b/_site/changelog/1.8.0/index.html
@@ -464,9 +464,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.8.1/index.html
+++ b/_site/changelog/1.8.1/index.html
@@ -454,9 +454,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.8.2/index.html
+++ b/_site/changelog/1.8.2/index.html
@@ -448,9 +448,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/1.9.0/index.html
+++ b/_site/changelog/1.9.0/index.html
@@ -449,9 +449,9 @@ This is essentially a copy/paste time saver. Enabling the &quot;Chain decoders&q
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/2.0.0/index.html
+++ b/_site/changelog/2.0.0/index.html
@@ -493,9 +493,9 @@ Accessible from the fly-out navigation and by clicking the site version number i
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/2.0.1/index.html
+++ b/_site/changelog/2.0.1/index.html
@@ -438,9 +438,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/2.0.2/index.html
+++ b/_site/changelog/2.0.2/index.html
@@ -459,9 +459,9 @@ Using <code>templateSyntax</code> is a weird but decent enough workaround to onl
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/2.0.3/index.html
+++ b/_site/changelog/2.0.3/index.html
@@ -14,7 +14,7 @@
         <meta property="og:description"
                 content="A simple JavaScript based tool to quickly convert text between different formats, and solve data driven puzzles using a variety of coding and decryption techniques" />
         <meta property="og:image" content="https://www.convrtr.xyz/assets/img/convrtr.jpeg" />
-        <title>Convrtr - Changelog: v1.15.2</title>
+        <title>Convrtr - Changelog: v2.0.3</title>
 
         <link rel="canonical" href="https://www.convrtr.xyz">
 
@@ -380,47 +380,32 @@
             <a href="/changelog" class="text-convrtr">changelog</a>
         </li>
         <li class="breadcrumb-item active" aria-current="page">
-            v1.15.2
+            v2.0.3
         </li>
         
     </ol>
 </nav>
 
         <div class="section-heading">
-            <h1 class="display-6">v1.15.2</h1>
+            <h1 class="display-6">v2.0.3</h1>
             <hr>
             <p class="px-2">
-                Released on November 11, 2024
+                Released on April 4, 2025
             </p>
             <div class="px-2">
-                <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                 <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
             </div>
         </div>
     </div>
 </section>
 <section class="section changelog">
     <article class="py-4 px-2 px-sm-4">
-        <h2>Bug fixes</h2>
-<h3>Label focus</h3>
+        <h2>Changes</h2>
 <ul>
-<li>Walking back some label changes to hex delimiter, adding back the <code>for</code> attribute so that clicking the label will correctly set focus</li>
-<li>Updated styling so that labels and switches get a cursor change</li>
+<li>Reversed the sorting of changelog tags list, so that the latest published version for that tag shows at the top</li>
 </ul>
 
 
-        
-        <div class="mt-4">
-            <a class="btn btn-convrtr" href="https://github.com/stickerboy/convrtrjs/releases/tag/v1.15.2-Release">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-github"
-                    viewBox="0 0 16 16">
-                    <path
-                    d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8" />
-                </svg>  
-                View on Github
-            </a>
-        </div>
         
 
     </article>

--- a/_site/changelog/2.0.3/index.html
+++ b/_site/changelog/2.0.3/index.html
@@ -403,6 +403,7 @@
         <h2>Changes</h2>
 <ul>
 <li>Reversed the sorting of changelog tags list, so that the latest published version for that tag shows at the top</li>
+<li>Added a true/false &quot;visible&quot; flag to all tags that will prevent them from appearing in the tags list (though they'll still be accessible directly, and if they are added to a changelog). Some tags are really for Github only, but want to sync them here and keep them in case they're ever needed</li>
 </ul>
 
 

--- a/_site/changelog/2.0.3/index.html
+++ b/_site/changelog/2.0.3/index.html
@@ -403,6 +403,7 @@
         <h2>Changes</h2>
 <ul>
 <li>Reversed the sorting of changelog tags list, so that the latest published version for that tag shows at the top</li>
+<li>Re-ordered tags in the labels file in a more sensible order</li>
 <li>Added a true/false &quot;visible&quot; flag to all tags that will prevent them from appearing in the tags list (though they'll still be accessible directly, and if they are added to a changelog). Some tags are really for Github only, but want to sync them here and keep them in case they're ever needed</li>
 </ul>
 

--- a/_site/changelog/2.0.3/index.html
+++ b/_site/changelog/2.0.3/index.html
@@ -394,6 +394,7 @@
             </p>
             <div class="px-2">
                 <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
             </div>
         </div>
     </div>

--- a/_site/changelog/2/index.html
+++ b/_site/changelog/2/index.html
@@ -411,6 +411,57 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/1.17.8/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.8
+                                    </a>
+                                </div>
+
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/1.17.6/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         1.17.6
                                     </a>
@@ -845,51 +896,6 @@
                         </td>
                     </tr>
                     
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.2/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.2
-                                    </a>
-                                </div>
-
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    
                 </tbody>
             </table>
         </div>
@@ -993,9 +999,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/3/index.html
+++ b/_site/changelog/3/index.html
@@ -411,6 +411,51 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/1.15.2/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.2
+                                    </a>
+                                </div>
+
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/1.15.1/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         1.15.1
                                     </a>
@@ -818,51 +863,6 @@
                         </td>
                     </tr>
                     
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.0/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.0
-                                    </a>
-                                </div>
-
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    
                 </tbody>
             </table>
         </div>
@@ -972,9 +972,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/4/index.html
+++ b/_site/changelog/4/index.html
@@ -411,6 +411,51 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/1.12.0/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.0
+                                    </a>
+                                </div>
+
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/1.11.0/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         1.11.0
                                     </a>
@@ -833,51 +878,6 @@
                         </td>
                     </tr>
                     
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.9.0/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.9.0
-                                    </a>
-                                </div>
-
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    
                 </tbody>
             </table>
         </div>
@@ -987,9 +987,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/5/index.html
+++ b/_site/changelog/5/index.html
@@ -411,6 +411,51 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/1.9.0/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.9.0
+                                    </a>
+                                </div>
+
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/1.8.2/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         1.8.2
                                     </a>
@@ -818,57 +863,6 @@
                         </td>
                     </tr>
                     
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.2/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
-                                    </a>
-                                </div>
-
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 20, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    
                 </tbody>
             </table>
         </div>
@@ -978,9 +972,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/6/index.html
+++ b/_site/changelog/6/index.html
@@ -411,6 +411,57 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/1.5.2/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.2
+                                    </a>
+                                </div>
+
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 20, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/1.5.1/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         1.5.1
                                     </a>
@@ -821,54 +872,6 @@
                         </td>
                     </tr>
                     
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.1.0/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.0
-                                    </a>
-                                </div>
-
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    
                 </tbody>
             </table>
         </div>
@@ -972,9 +975,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/7/index.html
+++ b/_site/changelog/7/index.html
@@ -411,6 +411,54 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/1.1.0/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.0
+                                    </a>
+                                </div>
+
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/1.0.1/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         1.0.1
                                     </a>
@@ -549,9 +597,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/index.html
+++ b/_site/changelog/index.html
@@ -411,6 +411,45 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/2.0.3/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.3
+                                    </a>
+                                </div>
+
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 04, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/2.0.2/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         2.0.2
                                     </a>
@@ -833,57 +872,6 @@
                         </td>
                     </tr>
                     
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.8/" class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
-                                    </a>
-                                </div>
-
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    
                 </tbody>
             </table>
         </div>
@@ -981,9 +969,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/index.html
+++ b/_site/changelog/index.html
@@ -438,6 +438,9 @@
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
                                 </div>
                             </div>
                         </td>

--- a/_site/changelog/tag/a11y/index.html
+++ b/_site/changelog/tag/a11y/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.15.1/"
+                                    <a href="/changelog/2.0.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.1
+                                        2.0.0
                                     </a>
                                 </div>
                     
@@ -431,7 +431,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 09, 2024
+                                    April 03, 2025
                                 </div>
                             </div>
                         </td>
@@ -446,60 +446,7 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -582,9 +529,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/2.0.0/"
+                                    <a href="/changelog/1.17.4/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.0
+                                        1.17.4
                                     </a>
                                 </div>
                     
@@ -596,7 +543,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 03, 2025
+                                    November 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -611,10 +558,63 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 09, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -665,9 +665,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/all/index.html
+++ b/_site/changelog/tag/all/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/assets/favicons/"
+                                    <a href="/changelog/2.0.3/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        
+                                        2.0.3
                                     </a>
                                 </div>
                     
@@ -431,121 +431,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 11, 2022
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/assets/img/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 11, 2022
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        For everlost and Grollow!
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 11, 2022
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.0.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.0.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    December 23, 2023
+                                    April 04, 2025
                                 </div>
                             </div>
                         </td>
@@ -559,8 +445,49 @@
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 04, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
                                     
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -581,9 +508,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.1.0/"
+                                    <a href="/changelog/2.0.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.0
+                                        2.0.1
                                     </a>
                                 </div>
                     
@@ -595,7 +522,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 11, 2024
+                                    April 03, 2025
                                 </div>
                             </div>
                         </td>
@@ -605,6 +532,188 @@
                                     Tags
                                 </div>
                                 <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/tags/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        Tags
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 02, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/tag/all/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        Changelog
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 01, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.20.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.20.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    December 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
@@ -612,12 +721,6 @@
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -631,9 +734,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/404.html"
+                                    <a href="/changelog/1.19.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        Zm91ciBvaCBmb3Vy
+                                        1.19.0
                                     </a>
                                 </div>
                     
@@ -645,121 +748,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/assets/css/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/assets/js/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.1.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 12, 2024
+                                    December 04, 2024
                                 </div>
                             </div>
                         </td>
@@ -771,54 +760,7 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
@@ -826,9 +768,6 @@
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -842,9 +781,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.2.1/"
+                                    <a href="/changelog/1.18.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
+                                        1.18.0
                                     </a>
                                 </div>
                     
@@ -856,242 +795,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.3.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.3.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.4.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.4.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
+                                    November 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -1114,6 +818,53 @@
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.9/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.9
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
@@ -1130,9 +881,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.1/"
+                                    <a href="/changelog/1.17.11/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.1
+                                        1.17.11
                                     </a>
                                 </div>
                     
@@ -1144,7 +895,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 19, 2024
+                                    November 25, 2024
                                 </div>
                             </div>
                         </td>
@@ -1157,6 +908,156 @@
                                     
                                     
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.10/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.10
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
@@ -1180,9 +1081,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/ciphers/"
+                                    <a href="/changelog/1.17.6/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        Cipher tools
+                                        1.17.6
                                     </a>
                                 </div>
                     
@@ -1194,7 +1095,163 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 19, 2024
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/sitemap/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        Sitemap
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 18, 2024
                                 </div>
                             </div>
                         </td>
@@ -1218,9 +1275,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/hex/"
+                                    <a href="/changelog/1.17.3/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        Hexadecimal tools
+                                        1.17.3
                                     </a>
                                 </div>
                     
@@ -1232,7 +1289,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 19, 2024
+                                    November 18, 2024
                                 </div>
                             </div>
                         </td>
@@ -1242,6 +1299,18 @@
                                     Tags
                                 </div>
                                 <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -1256,9 +1325,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.2/"
+                                    <a href="/changelog/1.17.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
+                                        1.17.2
                                     </a>
                                 </div>
                     
@@ -1270,7 +1339,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 20, 2024
+                                    November 17, 2024
                                 </div>
                             </div>
                         </td>
@@ -1309,9 +1378,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.3/"
+                                    <a href="/changelog/1.17.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.3
+                                        1.17.1
                                     </a>
                                 </div>
                     
@@ -1323,51 +1392,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
+                                    November 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -1383,56 +1408,6 @@
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.6.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.6.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -1450,9 +1425,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.7.0/"
+                                    <a href="/changelog/1.17.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.0
+                                        1.17.0
                                     </a>
                                 </div>
                     
@@ -1464,7 +1439,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 25, 2024
+                                    November 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -1486,147 +1461,6 @@
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -1644,9 +1478,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.8.1/"
+                                    <a href="/oni/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.1
+                                        ONI tools
                                     </a>
                                 </div>
                     
@@ -1658,7 +1492,424 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 31, 2024
+                                    November 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.16.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.16.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 09, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.14.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.14.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.14.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.14.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/assets/fonts/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    March 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.13.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.13.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
                                 </div>
                             </div>
                         </td>
@@ -1694,9 +1945,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.8.2/"
+                                    <a href="/changelog/1.12.4/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.2
+                                        1.12.4
                                     </a>
                                 </div>
                     
@@ -1708,7 +1959,327 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 31, 2024
+                                    February 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/misc/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        Miscellaneous tools
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.11.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.11.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.7
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
                                 </div>
                             </div>
                         </td>
@@ -1728,52 +2299,8 @@
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.9.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.9.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
                                     
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                 </div>
                             </div>
@@ -1788,9 +2315,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.0/"
+                                    <a href="/changelog/1.10.6/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.0
+                                        1.10.6
                                     </a>
                                 </div>
                     
@@ -1802,7 +2329,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 04, 2024
+                                    February 10, 2024
                                 </div>
                             </div>
                         </td>
@@ -1817,10 +2344,13 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -1838,9 +2368,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.1/"
+                                    <a href="/files/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.1
+                                        File tools
                                     </a>
                                 </div>
                     
@@ -1852,7 +2382,95 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 05, 2024
+                                    February 08, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 08, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 07, 2024
                                 </div>
                             </div>
                         </td>
@@ -1938,9 +2556,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.4/"
+                                    <a href="/changelog/1.10.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.4
+                                        1.10.1
                                     </a>
                                 </div>
                     
@@ -1952,7 +2570,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 07, 2024
+                                    February 05, 2024
                                 </div>
                             </div>
                         </td>
@@ -1988,9 +2606,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.5/"
+                                    <a href="/changelog/1.10.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.5
+                                        1.10.0
                                     </a>
                                 </div>
                     
@@ -2002,7 +2620,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 08, 2024
+                                    February 04, 2024
                                 </div>
                             </div>
                         </td>
@@ -2017,10 +2635,10 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
                                     
                                     
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -2038,9 +2656,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/files/"
+                                    <a href="/changelog/1.9.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        File tools
+                                        1.9.0
                                     </a>
                                 </div>
                     
@@ -2052,195 +2670,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 08, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.7
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.11.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.11.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
+                                    January 31, 2024
                                 </div>
                             </div>
                         </td>
@@ -2273,9 +2703,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/misc/"
+                                    <a href="/changelog/1.8.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        Miscellaneous tools
+                                        1.8.2
                                     </a>
                                 </div>
                     
@@ -2287,45 +2717,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
+                                    January 31, 2024
                                 </div>
                             </div>
                         </td>
@@ -2340,7 +2732,7 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -2358,9 +2750,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.12.1/"
+                                    <a href="/changelog/1.8.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.1
+                                        1.8.1
                                     </a>
                                 </div>
                     
@@ -2372,148 +2764,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
+                                    January 31, 2024
                                 </div>
                             </div>
                         </td>
@@ -2549,9 +2800,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.13.0/"
+                                    <a href="/changelog/1.8.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.13.0
+                                        1.8.0
                                     </a>
                                 </div>
                     
@@ -2563,7 +2814,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 17, 2024
+                                    January 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -2579,6 +2830,9 @@
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -2596,7 +2850,856 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/assets/fonts/"
+                                    <a href="/changelog/1.7.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.6.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.6.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 20, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/hex/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        Hexadecimal tools
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/ciphers/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        Cipher tools
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.4.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.4.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.3.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.3.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/assets/js/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         
                                     </a>
@@ -2610,7 +3713,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    March 06, 2024
+                                    January 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -2634,9 +3737,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.14.0/"
+                                    <a href="/assets/css/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.0
+                                        
                                     </a>
                                 </div>
                     
@@ -2648,7 +3751,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    October 28, 2024
+                                    January 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -2658,15 +3761,6 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -2681,9 +3775,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.14.1/"
+                                    <a href="/404.html"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.1
+                                        Zm91ciBvaCBmb3Vy
                                     </a>
                                 </div>
                     
@@ -2695,7 +3789,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    October 28, 2024
+                                    January 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -2705,15 +3799,6 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -2728,9 +3813,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.15.0/"
+                                    <a href="/changelog/1.1.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.0
+                                        1.1.0
                                     </a>
                                 </div>
                     
@@ -2742,7 +3827,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 06, 2024
+                                    January 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -2752,156 +3837,6 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 09, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.16.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.16.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
@@ -2928,9 +3863,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/oni/"
+                                    <a href="/changelog/1.0.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        ONI tools
+                                        1.0.1
                                     </a>
                                 </div>
                     
@@ -2942,7 +3877,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 14, 2024
+                                    December 23, 2023
                                 </div>
                             </div>
                         </td>
@@ -2952,147 +3887,6 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
@@ -3119,9 +3913,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.3/"
+                                    <a href="/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.3
+                                        For everlost and Grollow!
                                     </a>
                                 </div>
                     
@@ -3133,57 +3927,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 18, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/sitemap/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        Sitemap
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 18, 2024
+                                    November 11, 2022
                                 </div>
                             </div>
                         </td>
@@ -3207,9 +3951,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.4/"
+                                    <a href="/assets/img/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.4
+                                        
                                     </a>
                                 </div>
                     
@@ -3221,557 +3965,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.10/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.10
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.11/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.11
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.9/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.9
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.18.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.18.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.19.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.19.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    December 04, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.20.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.20.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    December 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/tag/all/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        Changelog
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 01, 2025
+                                    November 11, 2022
                                 </div>
                             </div>
                         </td>
@@ -3795,9 +3989,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/tags/"
+                                    <a href="/assets/favicons/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        Tags
+                                        
                                     </a>
                                 </div>
                     
@@ -3809,7 +4003,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 02, 2025
+                                    November 11, 2022
                                 </div>
                             </div>
                         </td>
@@ -3819,159 +4013,6 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 04, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -4013,9 +4054,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/all/index.html
+++ b/_site/changelog/tag/all/index.html
@@ -445,6 +445,9 @@
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
                                 </div>
                             </div>
                         </td>

--- a/_site/changelog/tag/bug-fixes/index.html
+++ b/_site/changelog/tag/bug-fixes/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.0.1/"
+                                    <a href="/changelog/2.0.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.0.1
+                                        2.0.2
                                     </a>
                                 </div>
                     
@@ -431,345 +431,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 23, 2023
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.1.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.1.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.3.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.3.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.4.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.4.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
+                                    April 04, 2025
                                 </div>
                             </div>
                         </td>
@@ -784,7 +446,310 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.9/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.9
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.11/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.11
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.10/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.10
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -808,9 +773,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.1/"
+                                    <a href="/changelog/1.17.7/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.1
+                                        1.17.6
                                     </a>
                                 </div>
                     
@@ -822,7 +787,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 19, 2024
+                                    November 21, 2024
                                 </div>
                             </div>
                         </td>
@@ -832,9 +797,6 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
@@ -858,9 +820,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.2/"
+                                    <a href="/changelog/1.17.5/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
+                                        1.17.5
                                     </a>
                                 </div>
                     
@@ -872,7 +834,169 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 20, 2024
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 18, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 17, 2024
                                 </div>
                             </div>
                         </td>
@@ -911,9 +1035,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.6.0/"
+                                    <a href="/changelog/1.17.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.6.0
+                                        1.17.1
                                     </a>
                                 </div>
                     
@@ -925,7 +1049,54 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 23, 2024
+                                    November 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -941,356 +1112,6 @@
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 04, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 05, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 06, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 07, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 08, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -1314,9 +1135,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.13.0/"
+                                    <a href="/changelog/1.16.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.13.0
+                                        1.16.0
                                     </a>
                                 </div>
                     
@@ -1328,7 +1149,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 17, 2024
+                                    November 12, 2024
                                 </div>
                             </div>
                         </td>
@@ -1346,51 +1167,10 @@
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
                                     
                                     
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.14.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    October 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -1408,9 +1188,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.14.1/"
+                                    <a href="/changelog/1.15.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.1
+                                        1.15.2
                                     </a>
                                 </div>
                     
@@ -1422,7 +1202,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    October 28, 2024
+                                    November 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -1508,9 +1288,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.15.2/"
+                                    <a href="/changelog/1.14.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.2
+                                        1.14.1
                                     </a>
                                 </div>
                     
@@ -1522,7 +1302,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 11, 2024
+                                    October 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -1555,9 +1335,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.16.0/"
+                                    <a href="/changelog/1.14.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.16.0
+                                        1.14.0
                                     </a>
                                 </div>
                     
@@ -1569,7 +1349,607 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 12, 2024
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.13.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.13.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.6/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 08, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 07, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 05, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 04, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.6.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.6.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 20, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -1608,9 +1988,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.0/"
+                                    <a href="/changelog/1.4.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.0
+                                        1.4.0
                                     </a>
                                 </div>
                     
@@ -1622,7 +2002,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 16, 2024
+                                    January 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -1634,7 +2014,242 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.3.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.3.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
@@ -1661,9 +2276,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.1/"
+                                    <a href="/changelog/1.0.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.1
+                                        1.0.1
                                     </a>
                                 </div>
                     
@@ -1675,7 +2290,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 16, 2024
+                                    December 23, 2023
                                 </div>
                             </div>
                         </td>
@@ -1685,627 +2300,12 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 18, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.10/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.10
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.11/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.11
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.9/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.9
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 04, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -2353,9 +2353,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/hotfix/index.html
+++ b/_site/changelog/tag/hotfix/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.1/"
+                                    <a href="/changelog/2.0.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.1
+                                        2.0.1
                                     </a>
                                 </div>
                     
@@ -431,7 +431,101 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 19, 2024
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 07, 2024
                                 </div>
                             </div>
                         </td>
@@ -517,9 +611,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.4/"
+                                    <a href="/changelog/1.5.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.4
+                                        1.5.1
                                     </a>
                                 </div>
                     
@@ -531,7 +625,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 07, 2024
+                                    January 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -553,100 +647,6 @@
                                     
                                     
                                     <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -688,9 +688,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/improvements/index.html
+++ b/_site/changelog/tag/improvements/index.html
@@ -417,6 +417,50 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
+                                    <a href="/changelog/2.0.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 04, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
                                     <a href="/changelog/2.0.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
                                         2.0.2

--- a/_site/changelog/tag/improvements/index.html
+++ b/_site/changelog/tag/improvements/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.0.1/"
+                                    <a href="/changelog/2.0.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.0.1
+                                        2.0.2
                                     </a>
                                 </div>
                     
@@ -431,7 +431,1704 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 23, 2023
+                                    April 04, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.18.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.18.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.9/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.9
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.11/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.11
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.6/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 18, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.16.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.16.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 09, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.7
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.6/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 08, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 20, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.4.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.4.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.3.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.3.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 12, 2024
                                 </div>
                             </div>
                         </td>
@@ -517,9 +2214,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.1.1/"
+                                    <a href="/changelog/1.0.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.1
+                                        1.0.1
                                     </a>
                                 </div>
                     
@@ -531,7 +2228,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 12, 2024
+                                    December 23, 2023
                                 </div>
                             </div>
                         </td>
@@ -547,1703 +2244,6 @@
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.3.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.3.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.4.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.4.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 20, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 08, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.7
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 09, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.16.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.16.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 18, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.11/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.11
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.9/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.9
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.18.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.18.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 04, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -2291,9 +2291,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/major/index.html
+++ b/_site/changelog/tag/major/index.html
@@ -500,9 +500,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/minor/index.html
+++ b/_site/changelog/tag/minor/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.1.0/"
+                                    <a href="/changelog/1.20.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.0
+                                        1.20.0
                                     </a>
                                 </div>
                     
@@ -431,7 +431,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 11, 2024
+                                    December 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -441,6 +441,103 @@
                                     Tags
                                 </div>
                                 <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.19.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.19.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    December 04, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.18.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.18.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
@@ -451,9 +548,6 @@
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -467,9 +561,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.2.0/"
+                                    <a href="/changelog/1.17.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
+                                        1.17.0
                                     </a>
                                 </div>
                     
@@ -481,148 +575,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.3.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.3.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.4.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.4.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
+                                    November 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -661,9 +614,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.6.0/"
+                                    <a href="/changelog/1.16.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.6.0
+                                        1.16.0
                                     </a>
                                 </div>
                     
@@ -675,7 +628,392 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 23, 2024
+                                    November 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.14.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.14.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.13.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.13.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.11.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.11.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 04, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.9.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.9.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -761,9 +1099,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.8.0/"
+                                    <a href="/changelog/1.6.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.0
+                                        1.6.0
                                     </a>
                                 </div>
                     
@@ -775,7 +1113,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 28, 2024
+                                    January 23, 2024
                                 </div>
                             </div>
                         </td>
@@ -811,9 +1149,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.9.0/"
+                                    <a href="/changelog/1.5.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.9.0
+                                        1.5.0
                                     </a>
                                 </div>
                     
@@ -825,339 +1163,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 04, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.11.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.11.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.13.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.13.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.14.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    October 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 06, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.16.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.16.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 12, 2024
+                                    January 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -1196,9 +1202,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.0/"
+                                    <a href="/changelog/1.4.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.0
+                                        1.4.0
                                     </a>
                                 </div>
                     
@@ -1210,7 +1216,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 16, 2024
+                                    January 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -1222,13 +1228,7 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -1249,9 +1249,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.18.0/"
+                                    <a href="/changelog/1.3.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.18.0
+                                        1.3.0
                                     </a>
                                 </div>
                     
@@ -1263,7 +1263,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 28, 2024
+                                    January 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -1275,7 +1275,51 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
                                     
                                     
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
@@ -1299,9 +1343,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.19.0/"
+                                    <a href="/changelog/1.1.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.19.0
+                                        1.1.0
                                     </a>
                                 </div>
                     
@@ -1313,7 +1357,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 04, 2024
+                                    January 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -1325,60 +1369,16 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
                                     <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.20.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.20.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    December 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -1420,9 +1420,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/new-features/index.html
+++ b/_site/changelog/tag/new-features/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.0.1/"
+                                    <a href="/changelog/2.0.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.0.1
+                                        2.0.0
                                     </a>
                                 </div>
                     
@@ -431,7 +431,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 23, 2023
+                                    April 03, 2025
                                 </div>
                             </div>
                         </td>
@@ -443,7 +443,10 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -454,55 +457,8 @@
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.1.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
                                     
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
                                     
                                 </div>
                             </div>
@@ -517,9 +473,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.1.1/"
+                                    <a href="/changelog/1.20.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.1
+                                        1.20.0
                                     </a>
                                 </div>
                     
@@ -531,151 +487,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
+                                    December 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -695,12 +507,6 @@
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -714,9 +520,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.2/"
+                                    <a href="/changelog/1.19.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
+                                        1.19.0
                                     </a>
                                 </div>
                     
@@ -728,107 +534,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 20, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.6.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.6.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
+                                    December 04, 2024
                                 </div>
                             </div>
                         </td>
@@ -848,9 +554,6 @@
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -864,9 +567,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.7.0/"
+                                    <a href="/changelog/1.18.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.0
+                                        1.18.0
                                     </a>
                                 </div>
                     
@@ -878,7 +581,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 25, 2024
+                                    November 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -914,9 +617,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.7.1/"
+                                    <a href="/changelog/1.17.10/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.1
+                                        1.17.10
                                     </a>
                                 </div>
                     
@@ -928,298 +631,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.9.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.9.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 04, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 06, 2024
+                                    November 25, 2024
                                 </div>
                             </div>
                         </td>
@@ -1255,9 +667,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.6/"
+                                    <a href="/changelog/1.17.8/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.6
+                                        1.17.8
                                     </a>
                                 </div>
                     
@@ -1269,407 +681,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.7
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.11.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.11.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 06, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.16.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.16.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 17, 2024
+                                    November 23, 2024
                                 </div>
                             </div>
                         </td>
@@ -1764,9 +776,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.8/"
+                                    <a href="/changelog/1.17.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
+                                        1.17.2
                                     </a>
                                 </div>
                     
@@ -1778,7 +790,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 23, 2024
+                                    November 17, 2024
                                 </div>
                             </div>
                         </td>
@@ -1817,9 +829,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.10/"
+                                    <a href="/changelog/1.17.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.10
+                                        1.17.0
                                     </a>
                                 </div>
                     
@@ -1831,7 +843,407 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 25, 2024
+                                    November 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.16.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.16.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.11.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.11.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.7
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.6/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 06, 2024
                                 </div>
                             </div>
                         </td>
@@ -1867,9 +1279,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.18.0/"
+                                    <a href="/changelog/1.10.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.18.0
+                                        1.10.0
                                     </a>
                                 </div>
                     
@@ -1881,7 +1293,298 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 28, 2024
+                                    February 04, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.9.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.9.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 25, 2024
                                 </div>
                             </div>
                         </td>
@@ -1917,9 +1620,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.19.0/"
+                                    <a href="/changelog/1.6.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.19.0
+                                        1.6.0
                                     </a>
                                 </div>
                     
@@ -1931,7 +1634,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 04, 2024
+                                    January 23, 2024
                                 </div>
                             </div>
                         </td>
@@ -1951,6 +1654,9 @@
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
                                 </div>
                             </div>
                         </td>
@@ -1964,9 +1670,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.20.0/"
+                                    <a href="/changelog/1.5.4/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.20.0
+                                        1.5.4
                                     </a>
                                 </div>
                     
@@ -1978,7 +1684,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 19, 2024
+                                    January 23, 2024
                                 </div>
                             </div>
                         </td>
@@ -1993,7 +1699,7 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -2011,9 +1717,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/2.0.0/"
+                                    <a href="/changelog/1.5.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.0
+                                        1.5.2
                                     </a>
                                 </div>
                     
@@ -2025,7 +1731,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 03, 2025
+                                    January 20, 2024
                                 </div>
                             </div>
                         </td>
@@ -2040,7 +1746,7 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -2051,8 +1757,302 @@
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
                                     
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.0.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.0.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    December 23, 2023
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -2094,9 +2094,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/patch/index.html
+++ b/_site/changelog/tag/patch/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.0.1/"
+                                    <a href="/changelog/2.0.3/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.0.1
+                                        2.0.3
                                     </a>
                                 </div>
                     
@@ -431,7 +431,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 23, 2023
+                                    April 04, 2025
                                 </div>
                             </div>
                         </td>
@@ -444,15 +444,6 @@
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -467,9 +458,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.1.1/"
+                                    <a href="/changelog/2.0.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.1
+                                        2.0.2
                                     </a>
                                 </div>
                     
@@ -481,198 +472,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
+                                    April 04, 2025
                                 </div>
                             </div>
                         </td>
@@ -685,6 +485,303 @@
                                     
                                     
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.9/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.9
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.11/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.11
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.10/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.10
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
@@ -708,9 +805,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.2/"
+                                    <a href="/changelog/1.17.6/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
+                                        1.17.6
                                     </a>
                                 </div>
                     
@@ -722,7 +819,213 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 20, 2024
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 18, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 17, 2024
                                 </div>
                             </div>
                         </td>
@@ -761,9 +1064,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.3/"
+                                    <a href="/changelog/1.17.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.3
+                                        1.17.1
                                     </a>
                                 </div>
                     
@@ -775,289 +1078,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 05, 2024
+                                    November 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -1077,9 +1098,6 @@
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -1093,9 +1111,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.3/"
+                                    <a href="/changelog/1.15.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.3
+                                        1.15.2
                                     </a>
                                 </div>
                     
@@ -1107,498 +1125,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 06, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 07, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 08, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.7
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.14.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    October 28, 2024
+                                    November 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -1684,9 +1211,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.15.2/"
+                                    <a href="/changelog/1.14.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.2
+                                        1.14.1
                                     </a>
                                 </div>
                     
@@ -1698,7 +1225,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 11, 2024
+                                    October 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -1731,9 +1258,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.1/"
+                                    <a href="/changelog/1.12.3/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.1
+                                        1.12.3
                                     </a>
                                 </div>
                     
@@ -1745,7 +1272,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 16, 2024
+                                    February 17, 2024
                                 </div>
                             </div>
                         </td>
@@ -1763,7 +1290,10 @@
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                 </div>
                             </div>
@@ -1778,9 +1308,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.2/"
+                                    <a href="/changelog/1.12.4/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.2
+                                        1.12.4
                                     </a>
                                 </div>
                     
@@ -1792,7 +1322,245 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 17, 2024
+                                    February 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.7
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.6/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
                                 </div>
                             </div>
                         </td>
@@ -1831,9 +1599,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.3/"
+                                    <a href="/changelog/1.10.5/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.3
+                                        1.10.5
                                     </a>
                                 </div>
                     
@@ -1845,7 +1613,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 18, 2024
+                                    February 08, 2024
                                 </div>
                             </div>
                         </td>
@@ -1881,9 +1649,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.4/"
+                                    <a href="/changelog/1.10.4/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.4
+                                        1.10.4
                                     </a>
                                 </div>
                     
@@ -1895,7 +1663,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 19, 2024
+                                    February 07, 2024
                                 </div>
                             </div>
                         </td>
@@ -1908,159 +1676,6 @@
                                     
                                     
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
@@ -2084,9 +1699,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.8/"
+                                    <a href="/changelog/1.10.3/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
+                                        1.10.3
                                     </a>
                                 </div>
                     
@@ -2098,60 +1713,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.10/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.10
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
+                                    February 06, 2024
                                 </div>
                             </div>
                         </td>
@@ -2187,9 +1749,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.11/"
+                                    <a href="/changelog/1.10.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.11
+                                        1.10.1
                                     </a>
                                 </div>
                     
@@ -2201,7 +1763,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 25, 2024
+                                    February 05, 2024
                                 </div>
                             </div>
                         </td>
@@ -2219,105 +1781,343 @@
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.9/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.9
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
                                     
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 20, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
@@ -2334,9 +2134,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/2.0.2/"
+                                    <a href="/changelog/1.5.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.2
+                                        1.5.1
                                     </a>
                                 </div>
                     
@@ -2348,7 +2148,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 04, 2025
+                                    January 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -2364,6 +2164,247 @@
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.0.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.0.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    December 23, 2023
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -2411,9 +2452,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/patch/index.html
+++ b/_site/changelog/tag/patch/index.html
@@ -445,6 +445,9 @@
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
                                 </div>
                             </div>
                         </td>

--- a/_site/changelog/tag/release/index.html
+++ b/_site/changelog/tag/release/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.0/"
+                                    <a href="/changelog/2.0.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.0
+                                        2.0.2
                                     </a>
                                 </div>
                     
@@ -431,7 +431,722 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 19, 2024
+                                    April 04, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.20.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.20.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    December 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.19.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.19.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    December 04, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.18.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.18.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.9/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.9
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.11/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.11
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.10/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.10
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 18, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 16, 2024
                                 </div>
                             </div>
                         </td>
@@ -470,9 +1185,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.1/"
+                                    <a href="/changelog/1.16.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.1
+                                        1.16.0
                                     </a>
                                 </div>
                     
@@ -484,7 +1199,60 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 19, 2024
+                                    November 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 11, 2024
                                 </div>
                             </div>
                         </td>
@@ -504,8 +1272,58 @@
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 09, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
                                     
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
                                     
                                 </div>
                             </div>
@@ -520,9 +1338,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.2/"
+                                    <a href="/changelog/1.15.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
+                                        1.15.0
                                     </a>
                                 </div>
                     
@@ -534,7 +1352,577 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 20, 2024
+                                    November 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.14.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.14.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.14.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.14.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.13.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.13.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.11.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.11.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.7/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.7
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.6/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.6
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 10, 2024
                                 </div>
                             </div>
                         </td>
@@ -573,9 +1961,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.5.4/"
+                                    <a href="/changelog/1.10.5/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.4
+                                        1.10.5
                                     </a>
                                 </div>
                     
@@ -587,201 +1975,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.6.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.6.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
+                                    February 08, 2024
                                 </div>
                             </div>
                         </td>
@@ -801,53 +1995,6 @@
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
@@ -864,9 +2011,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.8.1/"
+                                    <a href="/changelog/1.10.4/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.1
+                                        1.10.4
                                     </a>
                                 </div>
                     
@@ -878,201 +2025,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.9.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.9.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 04, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 05, 2024
+                                    February 07, 2024
                                 </div>
                             </div>
                         </td>
@@ -1158,9 +2111,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.4/"
+                                    <a href="/changelog/1.10.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.4
+                                        1.10.1
                                     </a>
                                 </div>
                     
@@ -1172,7 +2125,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 07, 2024
+                                    February 05, 2024
                                 </div>
                             </div>
                         </td>
@@ -1208,9 +2161,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.5/"
+                                    <a href="/changelog/1.10.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.5
+                                        1.10.0
                                     </a>
                                 </div>
                     
@@ -1222,7 +2175,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 08, 2024
+                                    February 04, 2024
                                 </div>
                             </div>
                         </td>
@@ -1237,10 +2190,10 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
                                     
                                     
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -1258,9 +2211,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.6/"
+                                    <a href="/changelog/1.9.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.6
+                                        1.9.0
                                     </a>
                                 </div>
                     
@@ -1272,157 +2225,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.7
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.11.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.11.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
+                                    January 31, 2024
                                 </div>
                             </div>
                         </td>
@@ -1455,9 +2258,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.12.0/"
+                                    <a href="/changelog/1.8.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.0
+                                        1.8.2
                                     </a>
                                 </div>
                     
@@ -1469,7 +2272,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 14, 2024
+                                    January 31, 2024
                                 </div>
                             </div>
                         </td>
@@ -1484,7 +2287,7 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -1502,9 +2305,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.12.1/"
+                                    <a href="/changelog/1.8.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.1
+                                        1.8.1
                                     </a>
                                 </div>
                     
@@ -1516,148 +2319,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
+                                    January 31, 2024
                                 </div>
                             </div>
                         </td>
@@ -1693,9 +2355,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.13.0/"
+                                    <a href="/changelog/1.8.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.13.0
+                                        1.8.0
                                     </a>
                                 </div>
                     
@@ -1707,295 +2369,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.14.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    October 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.14.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    October 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 06, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 09, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.16.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.16.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 12, 2024
+                                    January 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -2016,9 +2390,6 @@
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
@@ -2034,9 +2405,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.0/"
+                                    <a href="/changelog/1.7.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.0
+                                        1.7.2
                                     </a>
                                 </div>
                     
@@ -2048,60 +2419,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 16, 2024
+                                    January 27, 2024
                                 </div>
                             </div>
                         </td>
@@ -2119,7 +2437,7 @@
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                 </div>
                             </div>
@@ -2134,9 +2452,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.2/"
+                                    <a href="/changelog/1.7.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.2
+                                        1.7.1
                                     </a>
                                 </div>
                     
@@ -2148,7 +2466,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 17, 2024
+                                    January 27, 2024
                                 </div>
                             </div>
                         </td>
@@ -2168,12 +2486,6 @@
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -2187,9 +2499,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.3/"
+                                    <a href="/changelog/1.7.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.3
+                                        1.7.0
                                     </a>
                                 </div>
                     
@@ -2201,372 +2513,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 18, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.10/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.10
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.11/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.11
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.9/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.9
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.18.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.18.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 28, 2024
+                                    January 25, 2024
                                 </div>
                             </div>
                         </td>
@@ -2602,9 +2549,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.19.0/"
+                                    <a href="/changelog/1.6.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.19.0
+                                        1.6.0
                                     </a>
                                 </div>
                     
@@ -2616,7 +2563,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 04, 2024
+                                    January 23, 2024
                                 </div>
                             </div>
                         </td>
@@ -2635,110 +2582,10 @@
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.20.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.20.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    December 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/2.0.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    April 03, 2025
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -2752,9 +2599,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/2.0.2/"
+                                    <a href="/changelog/1.5.4/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.2
+                                        1.5.4
                                     </a>
                                 </div>
                     
@@ -2766,7 +2613,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 04, 2025
+                                    January 23, 2024
                                 </div>
                             </div>
                         </td>
@@ -2782,6 +2629,159 @@
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 20, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -2829,9 +2829,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/security/index.html
+++ b/_site/changelog/tag/security/index.html
@@ -500,9 +500,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/versions/index.html
+++ b/_site/changelog/tag/versions/index.html
@@ -417,9 +417,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/2.0.2/"
+                                    <a href="/changelog/1.0.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.2
+                                        1.0.1
                                     </a>
                                 </div>
                     
@@ -431,7 +431,1274 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 04, 2025
+                                    December 23, 2023
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.1.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.1.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 13, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.2.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.2.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.3.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.3.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.4.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.4.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 20, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 21, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.5.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.5.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.6.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.6.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 25, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.7.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.7.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 27, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.8.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.8.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.9.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.9.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    January 31, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 04, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 05, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 07, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.5/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.5
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 08, 2024
                                 </div>
                             </div>
                         </td>
@@ -467,9 +1734,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/2.0.1/"
+                                    <a href="/changelog/1.10.6/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.1
+                                        1.10.6
                                     </a>
                                 </div>
                     
@@ -481,7 +1748,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 03, 2025
+                                    February 10, 2024
                                 </div>
                             </div>
                         </td>
@@ -493,10 +1760,16 @@
                                 <div class="col">
                                     
                                     
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
@@ -514,9 +1787,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/2.0.0/"
+                                    <a href="/changelog/1.10.7/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        2.0.0
+                                        1.10.7
                                     </a>
                                 </div>
                     
@@ -528,7 +1801,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    April 03, 2025
+                                    February 10, 2024
                                 </div>
                             </div>
                         </td>
@@ -543,7 +1816,933 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.10.8/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.10.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.11.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.11.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 14, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.12.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.12.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.13.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.13.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    February 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.14.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.14.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.14.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.14.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    October 28, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 06, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 09, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.15.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.15.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 11, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.16.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.16.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 12, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.1/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.1
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 16, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.2/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.2
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 17, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.3/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.3
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 18, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.4/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.4
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 19, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -570,9 +2769,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.20.0/"
+                                    <a href="/changelog/1.17.5/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.20.0
+                                        1.17.5
                                     </a>
                                 </div>
                     
@@ -584,7 +2783,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 19, 2024
+                                    November 21, 2024
                                 </div>
                             </div>
                         </td>
@@ -599,10 +2798,19 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
                                     
                                 </div>
                             </div>
@@ -617,9 +2825,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.19.0/"
+                                    <a href="/changelog/1.17.7/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.19.0
+                                        1.17.6
                                     </a>
                                 </div>
                     
@@ -631,7 +2839,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    December 04, 2024
+                                    November 21, 2024
                                 </div>
                             </div>
                         </td>
@@ -643,13 +2851,13 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                     
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
                                     
                                 </div>
                             </div>
@@ -664,9 +2872,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.18.0/"
+                                    <a href="/changelog/1.17.6/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.18.0
+                                        1.17.6
                                     </a>
                                 </div>
                     
@@ -678,7 +2886,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 28, 2024
+                                    November 21, 2024
                                 </div>
                             </div>
                         </td>
@@ -690,13 +2898,7 @@
                                 <div class="col">
                                     
                                     
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
@@ -714,9 +2916,62 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.11/"
+                                    <a href="/changelog/1.17.8/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.11
+                                        1.17.8
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    November 23, 2024
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/1.17.9/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        1.17.9
                                     </a>
                                 </div>
                     
@@ -814,9 +3069,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.9/"
+                                    <a href="/changelog/1.17.11/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.9
+                                        1.17.11
                                     </a>
                                 </div>
                     
@@ -864,9 +3119,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.8/"
+                                    <a href="/changelog/1.18.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.8
+                                        1.18.0
                                     </a>
                                 </div>
                     
@@ -878,7 +3133,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 23, 2024
+                                    November 28, 2024
                                 </div>
                             </div>
                         </td>
@@ -893,7 +3148,7 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -901,9 +3156,6 @@
                                     
                                     <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
                                     
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
                                 </div>
                             </div>
                         </td>
@@ -917,9 +3169,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.6/"
+                                    <a href="/changelog/1.19.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
+                                        1.19.0
                                     </a>
                                 </div>
                     
@@ -931,98 +3183,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 21, 2024
+                                    December 04, 2024
                                 </div>
                             </div>
                         </td>
@@ -1037,19 +3198,10 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
                                     
                                     
-                                    <a href="/changelog/tag/security" class="badge git-badge badge-security" title="Security/vulnerability/CVE related updates">security</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
                                     
                                 </div>
                             </div>
@@ -1064,9 +3216,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.4/"
+                                    <a href="/changelog/1.20.0/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.4
+                                        1.20.0
                                     </a>
                                 </div>
                     
@@ -1078,7 +3230,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 19, 2024
+                                    December 19, 2024
                                 </div>
                             </div>
                         </td>
@@ -1093,7 +3245,54 @@
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
+                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
+                                    
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                
+                
+                    <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Version</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/2.0.0/"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
+                                        2.0.0
+                                    </a>
+                                </div>
+                    
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Date
+                                </div>
+                                <div class="col">
+                                    April 03, 2025
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Tags
+                                </div>
+                                <div class="col">
+                                    
+                                    
+                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
+                                    
+                                    
+                                    <a href="/changelog/tag/major" class="badge git-badge badge-major" title="Major feature updates">major</a>
                                     
                                     
                                     <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
@@ -1120,9 +3319,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.17.3/"
+                                    <a href="/changelog/2.0.1/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.3
+                                        2.0.1
                                     </a>
                                 </div>
                     
@@ -1134,7 +3333,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    November 18, 2024
+                                    April 03, 2025
                                 </div>
                             </div>
                         </td>
@@ -1144,1095 +3343,13 @@
                                     Tags
                                 </div>
                                 <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.17.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.17.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.16.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.16.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 09, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/a11y" class="badge git-badge badge-a11y" title="Accessibility improvements">a11y</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.15.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.15.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    November 06, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.14.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    October 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.14.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.14.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    October 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.13.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.13.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 17, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.12.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.12.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.11.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.11.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.8/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.8
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.7/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.7
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.6/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.6
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 10, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.5/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.5
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 08, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 07, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                     
                                     <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
                                     
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 06, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
                                     
                                     <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
@@ -2249,9 +3366,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.10.1/"
+                                    <a href="/changelog/2.0.2/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.1
+                                        2.0.2
                                     </a>
                                 </div>
                     
@@ -2263,7 +3380,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    February 05, 2024
+                                    April 04, 2025
                                 </div>
                             </div>
                         </td>
@@ -2276,832 +3393,6 @@
                                     
                                     
                                     <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.10.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.10.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    February 04, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.9.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.9.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 31, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.8.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.8.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 28, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 27, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.7.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.7.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 25, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.6.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.6.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.4/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.4
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 23, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 21, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.2/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.2
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 20, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/hotfix" class="badge git-badge badge-hotfix" title="Quick fix to resolve a bug or minor issue">hotfix</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.5.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.5.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 19, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/release" class="badge git-badge badge-release" title="Officially tagged and released version">release</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.4.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.4.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.3.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.3.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 16, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.3/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.3
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 14, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
@@ -3125,9 +3416,9 @@
                                     <span class="fs-6 fw-medium">Version</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/1.2.2/"
+                                    <a href="/changelog/2.0.3/"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.2
+                                        2.0.3
                                     </a>
                                 </div>
                     
@@ -3139,7 +3430,7 @@
                                     Date
                                 </div>
                                 <div class="col">
-                                    January 14, 2024
+                                    April 04, 2025
                                 </div>
                             </div>
                         </td>
@@ -3152,256 +3443,6 @@
                                     
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.2.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.2.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 13, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.1.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 12, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.1.0/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.1.0
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    January 11, 2024
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/minor" class="badge git-badge badge-minor" title="Minor feature updates">minor</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
-                                    
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                
-                
-                    <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Version</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/1.0.1/"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr">
-                                        1.0.1
-                                    </a>
-                                </div>
-                    
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Date
-                                </div>
-                                <div class="col">
-                                    December 23, 2023
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Tags
-                                </div>
-                                <div class="col">
-                                    
-                                    
-                                    <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/new-features" class="badge git-badge badge-new-features" title="Introduction of new features">new-features</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
-                                    
-                                    
-                                    <a href="/changelog/tag/bug-fixes" class="badge git-badge badge-bug-fixes" title="Fixed something that wasn't working">bug-fixes</a>
                                     
                                 </div>
                             </div>
@@ -3443,9 +3484,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/changelog/tag/versions/index.html
+++ b/_site/changelog/tag/versions/index.html
@@ -3444,6 +3444,9 @@
                                     
                                     <a href="/changelog/tag/patch" class="badge git-badge badge-patch" title="Bug fixes and patches">patch</a>
                                     
+                                    
+                                    <a href="/changelog/tag/improvements" class="badge git-badge badge-improvements" title="General improvements">improvements</a>
+                                    
                                 </div>
                             </div>
                         </td>

--- a/_site/ciphers/index.html
+++ b/_site/ciphers/index.html
@@ -1343,9 +1343,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/files/index.html
+++ b/_site/files/index.html
@@ -1000,9 +1000,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/hex/index.html
+++ b/_site/hex/index.html
@@ -664,9 +664,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/index.html
+++ b/_site/index.html
@@ -1135,9 +1135,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/misc/index.html
+++ b/_site/misc/index.html
@@ -1637,9 +1637,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/oni/index.html
+++ b/_site/oni/index.html
@@ -759,9 +759,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/sitemap/index.html
+++ b/_site/sitemap/index.html
@@ -599,9 +599,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/tags/index.html
+++ b/_site/tags/index.html
@@ -403,7 +403,8 @@
                         <th scope="col">Description</th>
                     </tr>
                 </thead>
-                <tbody class="table-group-divider"><tr class="position-relative">
+                <tbody class="table-group-divider">
+                <tr class="position-relative">
                         <th scope="row">
                             <div class="row">
                                 <div class="col-3 col-sm-2 d-md-none">
@@ -554,50 +555,6 @@
                                     <span class="fs-6 fw-medium">Tag</span>
                                 </div>
                                 <div class="col">
-                                    <span class="badge git-badge badge-bug">bug</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <span class="fw-normal">bug</span> 
-                                    (0)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Bug
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    Something isn't working
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
                                     <span class="badge git-badge badge-documentation">documentation</span>
                                 </div>
                             </div>
@@ -631,50 +588,6 @@
                                 </div>
                                 <div class="col">
                                     Improvements or additions to documentation
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
-                                    <span class="badge git-badge badge-duplicate">duplicate</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <span class="fw-normal">duplicate</span> 
-                                    (0)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Duplicate
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    This issue or pull request already exists
                                 </div>
                             </div>
                         </td>
@@ -970,50 +883,6 @@
                                     <span class="fs-6 fw-medium">Tag</span>
                                 </div>
                                 <div class="col">
-                                    <span class="badge git-badge badge-question">question</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <span class="fw-normal">question</span> 
-                                    (0)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Question
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    A query about the repo, tools, code, etc
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
                                     <span class="badge git-badge badge-release">release</span>
                                 </div>
                             </div>
@@ -1099,50 +968,6 @@
                                 </div>
                                 <div class="col">
                                     Security/vulnerability/CVE related updates
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
-                                    <span class="badge git-badge badge-wontfix">wontfix</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <span class="fw-normal">wontfix</span> 
-                                    (0)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Won't fix
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    This will not be worked on or fixed
                                 </div>
                             </div>
                         </td>

--- a/_site/tags/index.html
+++ b/_site/tags/index.html
@@ -937,7 +937,7 @@
                                         title="Changelog items tagged with patch">
                                         patch
                                     </a>
-                                    (40)
+                                    (41)
                                 </div>
                     
                             </div>
@@ -1179,9 +1179,9 @@
         </div>
         <div class="p-4 pt-2">
             <a href="/changelog"" 
-                title="Release version: v2.0.2" 
+                title="Release version: v2.0.3" 
                 class="d-inline-flex fw-semibold bg-convrtr border border-convrtr border-opacity-10 rounded-2 text-white release-version">
-                <small>v2.0.2</small>
+                <small>v2.0.3</small>
             </a>
         </div>
     </div>

--- a/_site/tags/index.html
+++ b/_site/tags/index.html
@@ -714,7 +714,7 @@
                                         title="Changelog items tagged with improvements">
                                         improvements
                                     </a>
-                                    (37)
+                                    (38)
                                 </div>
                     
                             </div>

--- a/_site/tags/index.html
+++ b/_site/tags/index.html
@@ -411,7 +411,7 @@
                                     <span class="fs-6 fw-medium">Tag</span>
                                 </div>
                                 <div class="col">
-                                    <span class="badge git-badge badge-improvements">improvements</span>
+                                    <span class="badge git-badge badge-release">release</span>
                                 </div>
                             </div>
                         </th>
@@ -421,12 +421,12 @@
                                     <span class="fs-6 fw-medium">Link</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/tag/improvements"
+                                    <a href="/changelog/tag/release"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
-                                        title="Changelog items tagged with improvements">
-                                        improvements
+                                        title="Changelog items tagged with release">
+                                        release
                                     </a>
-                                    (37)
+                                    (48)
                                 </div>
                     
                             </div>
@@ -437,7 +437,7 @@
                                     Name
                                 </div>
                                 <div class="col">
-                                    Improvements
+                                    Release
                                 </div>
                             </div>
                         </td>
@@ -447,239 +447,7 @@
                                     Description
                                 </div>
                                 <div class="col">
-                                    General improvements
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
-                                    <span class="badge git-badge badge-a11y">a11y</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/tag/a11y"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
-                                        title="Changelog items tagged with a11y">
-                                        a11y
-                                    </a>
-                                    (4)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Accessibility
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    Accessibility improvements
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
-                                    <span class="badge git-badge badge-bug-fixes">bug-fixes</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/tag/bug-fixes"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
-                                        title="Changelog items tagged with bug-fixes">
-                                        bug-fixes
-                                    </a>
-                                    (38)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Bug Fixes
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    Fixed something that wasn't working
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
-                                    <span class="badge git-badge badge-documentation">documentation</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <span class="fw-normal">documentation</span> 
-                                    (0)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Documentation
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    Improvements or additions to documentation
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
-                                    <span class="badge git-badge badge-feature-request">feature-request</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <span class="fw-normal">feature-request</span> 
-                                    (0)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Feature request
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    New feature or request
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
-                                    <span class="badge git-badge badge-hotfix">hotfix</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/tag/hotfix"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
-                                        title="Changelog items tagged with hotfix">
-                                        hotfix
-                                    </a>
-                                    (5)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    Hotfix
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    Quick fix to resolve a bug or minor issue
+                                    Officially tagged and released version
                                 </div>
                             </div>
                         </td>
@@ -787,54 +555,6 @@
                                     <span class="fs-6 fw-medium">Tag</span>
                                 </div>
                                 <div class="col">
-                                    <span class="badge git-badge badge-new-features">new-features</span>
-                                </div>
-                            </div>
-                        </th>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Link</span>
-                                </div>
-                                <div class="col">
-                                    <a href="/changelog/tag/new-features"
-                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
-                                        title="Changelog items tagged with new-features">
-                                        new-features
-                                    </a>
-                                    (33)
-                                </div>
-                    
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Name
-                                </div>
-                                <div class="col">
-                                    New Features
-                                </div>
-                            </div>
-                        </td>
-                        <td>
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    Description
-                                </div>
-                                <div class="col">
-                                    Introduction of new features
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <tr class="position-relative">
-                        <th scope="row">
-                            <div class="row">
-                                <div class="col-3 col-sm-2 d-md-none">
-                                    <span class="fs-6 fw-medium">Tag</span>
-                                </div>
-                                <div class="col">
                                     <span class="badge git-badge badge-patch">patch</span>
                                 </div>
                             </div>
@@ -883,7 +603,7 @@
                                     <span class="fs-6 fw-medium">Tag</span>
                                 </div>
                                 <div class="col">
-                                    <span class="badge git-badge badge-release">release</span>
+                                    <span class="badge git-badge badge-hotfix">hotfix</span>
                                 </div>
                             </div>
                         </th>
@@ -893,12 +613,12 @@
                                     <span class="fs-6 fw-medium">Link</span>
                                 </div>
                                 <div class="col">
-                                    <a href="/changelog/tag/release"
+                                    <a href="/changelog/tag/hotfix"
                                         class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
-                                        title="Changelog items tagged with release">
-                                        release
+                                        title="Changelog items tagged with hotfix">
+                                        hotfix
                                     </a>
-                                    (48)
+                                    (5)
                                 </div>
                     
                             </div>
@@ -909,7 +629,7 @@
                                     Name
                                 </div>
                                 <div class="col">
-                                    Release
+                                    Hotfix
                                 </div>
                             </div>
                         </td>
@@ -919,7 +639,151 @@
                                     Description
                                 </div>
                                 <div class="col">
-                                    Officially tagged and released version
+                                    Quick fix to resolve a bug or minor issue
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Tag</span>
+                                </div>
+                                <div class="col">
+                                    <span class="badge git-badge badge-new-features">new-features</span>
+                                </div>
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Link</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/tag/new-features"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
+                                        title="Changelog items tagged with new-features">
+                                        new-features
+                                    </a>
+                                    (33)
+                                </div>
+                    
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Name
+                                </div>
+                                <div class="col">
+                                    New Features
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Description
+                                </div>
+                                <div class="col">
+                                    Introduction of new features
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Tag</span>
+                                </div>
+                                <div class="col">
+                                    <span class="badge git-badge badge-improvements">improvements</span>
+                                </div>
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Link</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/tag/improvements"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
+                                        title="Changelog items tagged with improvements">
+                                        improvements
+                                    </a>
+                                    (37)
+                                </div>
+                    
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Name
+                                </div>
+                                <div class="col">
+                                    Improvements
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Description
+                                </div>
+                                <div class="col">
+                                    General improvements
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Tag</span>
+                                </div>
+                                <div class="col">
+                                    <span class="badge git-badge badge-bug-fixes">bug-fixes</span>
+                                </div>
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Link</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/tag/bug-fixes"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
+                                        title="Changelog items tagged with bug-fixes">
+                                        bug-fixes
+                                    </a>
+                                    (38)
+                                </div>
+                    
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Name
+                                </div>
+                                <div class="col">
+                                    Bug Fixes
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Description
+                                </div>
+                                <div class="col">
+                                    Fixed something that wasn't working
                                 </div>
                             </div>
                         </td>
@@ -968,6 +832,142 @@
                                 </div>
                                 <div class="col">
                                     Security/vulnerability/CVE related updates
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Tag</span>
+                                </div>
+                                <div class="col">
+                                    <span class="badge git-badge badge-a11y">a11y</span>
+                                </div>
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Link</span>
+                                </div>
+                                <div class="col">
+                                    <a href="/changelog/tag/a11y"
+                                        class="fw-medium stretched-link link-underline link-underline-opacity-0 text-convrtr"
+                                        title="Changelog items tagged with a11y">
+                                        a11y
+                                    </a>
+                                    (4)
+                                </div>
+                    
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Name
+                                </div>
+                                <div class="col">
+                                    Accessibility
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Description
+                                </div>
+                                <div class="col">
+                                    Accessibility improvements
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Tag</span>
+                                </div>
+                                <div class="col">
+                                    <span class="badge git-badge badge-documentation">documentation</span>
+                                </div>
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Link</span>
+                                </div>
+                                <div class="col">
+                                    <span class="fw-normal">documentation</span> 
+                                    (0)
+                                </div>
+                    
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Name
+                                </div>
+                                <div class="col">
+                                    Documentation
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Description
+                                </div>
+                                <div class="col">
+                                    Improvements or additions to documentation
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                <tr class="position-relative">
+                        <th scope="row">
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Tag</span>
+                                </div>
+                                <div class="col">
+                                    <span class="badge git-badge badge-feature-request">feature-request</span>
+                                </div>
+                            </div>
+                        </th>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    <span class="fs-6 fw-medium">Link</span>
+                                </div>
+                                <div class="col">
+                                    <span class="fw-normal">feature-request</span> 
+                                    (0)
+                                </div>
+                    
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Name
+                                </div>
+                                <div class="col">
+                                    Feature request
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="row">
+                                <div class="col-3 col-sm-2 d-md-none">
+                                    Description
+                                </div>
+                                <div class="col">
+                                    New feature or request
                                 </div>
                             </div>
                         </td>

--- a/changelog/2.0.3.md
+++ b/changelog/2.0.3.md
@@ -8,4 +8,5 @@ layout: layout/version.liquid
 ---
 ## Changes
 - Reversed the sorting of changelog tags list, so that the latest published version for that tag shows at the top
+- Re-ordered tags in the labels file in a more sensible order
 - Added a true/false "visible" flag to all tags that will prevent them from appearing in the tags list (though they'll still be accessible directly, and if they are added to a changelog). Some tags are really for Github only, but want to sync them here and keep them in case they're ever needed

--- a/changelog/2.0.3.md
+++ b/changelog/2.0.3.md
@@ -1,0 +1,10 @@
+---
+title: "2.0.3"
+date: "2025-04-04"
+page-id: "changelog"
+tags: 
+ - patch
+layout: layout/version.liquid
+---
+## Changes
+- Reversed the sorting of changelog tags list, so that the latest published version for that tag shows at the top

--- a/changelog/2.0.3.md
+++ b/changelog/2.0.3.md
@@ -8,3 +8,4 @@ layout: layout/version.liquid
 ---
 ## Changes
 - Reversed the sorting of changelog tags list, so that the latest published version for that tag shows at the top
+- Added a true/false "visible" flag to all tags that will prevent them from appearing in the tags list (though they'll still be accessible directly, and if they are added to a changelog). Some tags are really for Github only, but want to sync them here and keep them in case they're ever needed

--- a/changelog/2.0.3.md
+++ b/changelog/2.0.3.md
@@ -4,6 +4,7 @@ date: "2025-04-04"
 page-id: "changelog"
 tags: 
  - patch
+ - improvements
 layout: layout/version.liquid
 ---
 ## Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convrtrjs",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A simple JavaScript based tool to quickly convert text between different formats, and solve data driven puzzles using a variety of coding and decryption techniques",
   "tagline": "For everlost and Grollow!",
   "main": "index.html",

--- a/tag.html
+++ b/tag.html
@@ -27,7 +27,7 @@ eleventyComputed:
                 <tbody class="table-group-divider">
                 {% if tag %}
                 {% assign postListItems = collections[tag] %}
-                {% for version in postListItems %}
+                {% for version in postListItems reversed %}
                 
                     <tr class="position-relative">
                         <th scope="row">

--- a/tags.html
+++ b/tags.html
@@ -23,7 +23,8 @@ eleventyComputed:
                     </tr>
                 </thead>
                 <tbody class="table-group-divider">
-                {%- for tag in labels.labels -%}
+                {% assign visible_labels = labels.labels | where: "visible", true %}
+                {%- for tag in visible_labels -%}
                     {%- assign tagKey = tag.key | downcase | strip -%}
                     {%- assign tagCount = 0 -%}
 


### PR DESCRIPTION
## Changes
- Reversed the sorting of changelog tags list, so that the latest published version for that tag shows at the top
- Re-ordered tags in the labels file in a more sensible order
- Added a true/false "visible" flag to all tags that will prevent them from appearing in the tags list (though they'll still be accessible directly, and if they are added to a changelog). Some tags are really for Github only, but want to sync them here and keep them in case they're ever needed